### PR TITLE
Test suite [Jules]

### DIFF
--- a/rustyssh/rfc4250.txt
+++ b/rustyssh/rfc4250.txt
@@ -1,0 +1,1119 @@
+Network Working Group                                        S. Lehtinen
+Request for Comments: 4250              SSH Communications Security Corp
+Category: Standards Track                                C. Lonvick, Ed.
+                                                     Cisco Systems, Inc.
+                                                            January 2006
+
+
+            The Secure Shell (SSH) Protocol Assigned Numbers
+
+Status of This Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2006).
+
+Abstract
+
+   This document defines the instructions to the IANA and the initial
+   state of the IANA assigned numbers for the Secure Shell (SSH)
+   protocol.  It is intended only for the initialization of the IANA
+   registries referenced in the set of SSH documents.
+
+Table of Contents
+
+   1. Introduction ....................................................2
+   2. Contributors ....................................................3
+   3. Conventions Used in This Document ...............................3
+      3.1. RFC 2119 Keywords ..........................................3
+      3.2. RFC 2434 Keywords ..........................................3
+      3.3. Protocol Fields and Values .................................4
+   4. IANA Considerations .............................................5
+      4.1. Message Numbers ............................................5
+           4.1.1. Conventions .........................................5
+           4.1.2. Initial Assignments .................................6
+           4.1.3. Future Assignments ..................................6
+      4.2. Disconnection Messages Reason Codes and Descriptions .......7
+           4.2.1. Conventions .........................................7
+           4.2.2. Initial Assignments .................................7
+           4.2.3. Future Assignments ..................................8
+      4.3. Channel Connection Failure Reason Codes and Descriptions ...8
+           4.3.1. Conventions .........................................8
+           4.3.2. Initial Assignments .................................8
+
+
+
+Lehtinen & Lonvick          Standards Track                     [Page 1]
+
+RFC 4250             SSH Protocol Assigned Numbers          January 2006
+
+
+           4.3.3. Future Assignments ..................................8
+           4.3.4. Notes about the PRIVATE USE Range ...................9
+      4.4. Extended Channel Data Transfer data_type_code and Data .....9
+           4.4.1. Conventions .........................................9
+           4.4.2. Initial Assignments ................................10
+           4.4.3. Future Assignments .................................10
+      4.5. Pseudo-Terminal Encoded Terminal Modes ....................10
+           4.5.1. Conventions ........................................10
+           4.5.2. Initial Assignments ................................10
+           4.5.3. Future Assignments .................................12
+      4.6. Names .....................................................12
+           4.6.1. Conventions for Names ..............................13
+           4.6.2. Future Assignments of Names ........................13
+      4.7. Service Names .............................................13
+      4.8. Authentication Method Names ...............................14
+      4.9. Connection Protocol Assigned Names ........................14
+           4.9.1. Connection Protocol Channel Types ..................14
+           4.9.2. Connection Protocol Global Request Names ...........14
+           4.9.3. Connection Protocol Channel Request Names ..........15
+           4.9.4. Initial Assignment of Signal Names .................15
+           4.9.5. Connection Protocol Subsystem Names ................15
+      4.10. Key Exchange Method Names ................................16
+      4.11. Assigned Algorithm Names .................................16
+           4.11.1. Encryption Algorithm Names ........................16
+           4.11.2. MAC Algorithm Names ...............................17
+           4.11.3. Public Key Algorithm Names ........................17
+           4.11.4. Compression Algorithm Names .......................17
+   5. Security Considerations ........................................17
+   6. References .....................................................18
+      6.1. Normative References ......................................18
+      6.2. Informative References ....................................18
+   Authors' Addresses ................................................19
+   Trademark Notice ..................................................19
+
+1.  Introduction
+
+   This document does not define any new protocols.  It is intended only
+   to create the initial state of the IANA databases for the SSH
+   protocol and also contains instructions for future assignments.
+   Except for one HISTORIC algorithm generally regarded as obsolete,
+   this document does not define any new protocols or number ranges not
+   already defined in: [SSH-ARCH], [SSH-TRANS], [SSH-USERAUTH],
+   [SSH-CONNECT].
+
+
+
+
+
+
+
+
+Lehtinen & Lonvick          Standards Track                     [Page 2]
+
+RFC 4250             SSH Protocol Assigned Numbers          January 2006
+
+
+2.  Contributors
+
+   The major original contributors of this set of documents have been:
+   Tatu Ylonen, Tero Kivinen, Timo J. Rinne, Sami Lehtinen (all of SSH
+   Communications Security Corp), and Markku-Juhani O. Saarinen
+   (University of Jyvaskyla).  Darren Moffat was the original editor of
+   this set of documents and also made very substantial contributions.
+
+   Many people contributed to the development of this document over the
+   years.  People who should be acknowledged include Mats Andersson, Ben
+   Harris, Bill Sommerfeld, Brent McClure, Niels Moller, Damien Miller,
+   Derek Fawcus, Frank Cusack, Heikki Nousiainen, Jakob Schlyter, Jeff
+   Van Dyke, Jeffrey Altman, Jeffrey Hutzelman, Jon Bright, Joseph
+   Galbraith, Ken Hornstein, Markus Friedl, Martin Forssen, Nicolas
+   Williams, Niels Provos, Perry Metzger, Peter Gutmann, Simon
+   Josefsson, Simon Tatham, Wei Dai, Denis Bider, der Mouse, and
+   Tadayoshi Kohno.  Listing their names here does not mean that they
+   endorse this document, but that they have contributed to it.
+
+3.  Conventions Used in This Document
+
+3.1.  RFC 2119 Keywords
+
+   All documents related to the SSH protocols shall use the keywords
+   "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+   "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" to describe
+   requirements.  These keywords are to be interpreted as described in
+   [RFC2119].
+
+3.2.  RFC 2434 Keywords
+
+   The keywords "PRIVATE USE", "HIERARCHICAL ALLOCATION", "FIRST COME
+   FIRST SERVED", "EXPERT REVIEW", "SPECIFICATION REQUIRED", "IESG
+   APPROVAL", "IETF CONSENSUS", and "STANDARDS ACTION" that appear in
+   this document when used to describe namespace allocation are to be
+   interpreted as described in [RFC2434].  These designations are
+   repeated in this document for clarity.
+
+   PRIVATE USE - For private or local use only, with the type and
+   purpose defined by the local site.  No attempt is made to prevent
+   multiple sites from using the same value in different (and
+   incompatible) ways.  There is no need for IANA to review such
+   assignments and assignments are not generally useful for
+   interoperability.
+
+
+
+
+
+
+
+Lehtinen & Lonvick          Standards Track                     [Page 3]
+
+RFC 4250             SSH Protocol Assigned Numbers          January 2006
+
+
+   HIERARCHICAL ALLOCATION - Delegated managers can assign values
+   provided they have been given control over that part of the name
+   space.  IANA controls the higher levels of the namespace according to
+   one of the other policies.
+
+   FIRST COME FIRST SERVED - Anyone can obtain an assigned number, so
+   long as they provide a point of contact and a brief description of
+   what the value would be used for.  For numbers, the exact value is
+   generally assigned by the IANA; with names, specific names are
+   usually requested.
+
+   EXPERT REVIEW - approval by a Designated Expert is required.
+
+   SPECIFICATION REQUIRED - Values and their meaning must be documented
+   in an RFC or other permanent and readily available reference, in
+   sufficient detail so that interoperability between independent
+   implementations is possible.
+
+   IESG APPROVAL - New assignments must be approved by the IESG, but
+   there is no requirement that the request be documented in an RFC
+   (though the IESG has discretion to request documents or other
+   supporting materials on a case-by-case basis).
+
+   IETF CONSENSUS - New values are assigned through the IETF consensus
+   process.  Specifically, new assignments are made via RFCs approved by
+   the IESG.  Typically, the IESG will seek input on prospective
+   assignments from appropriate persons (e.g., a relevant Working Group
+   if one exists).
+
+   STANDARDS ACTION - Values are assigned only for Standards Track RFCs
+   approved by the IESG.
+
+3.3.  Protocol Fields and Values
+
+   Protocol fields and possible values to fill them are defined in this
+   set of documents.  Protocol fields will be defined in the message
+   definitions.  As an example, SSH_MSG_CHANNEL_DATA is defined as
+   follows.
+
+      byte      SSH_MSG_CHANNEL_DATA
+      uint32    recipient channel
+      string    data
+
+   Throughout these documents, when the fields are referenced, they will
+   appear within single quotes.  When values to fill those fields are
+   referenced, they will appear within double quotes.  Using the above
+   example, possible values for 'data' are "foo" and "bar".
+
+
+
+
+Lehtinen & Lonvick          Standards Track                     [Page 4]
+
+RFC 4250             SSH Protocol Assigned Numbers          January 2006
+
+
+4.  IANA Considerations
+
+   This entire document is the IANA considerations for the SSH protocol,
+   as defined in [SSH-ARCH], [SSH-TRANS], [SSH-USERAUTH], [SSH-CONNECT].
+   This section contains conventions used in naming the namespaces, the
+   initial state of the registry, and instructions for future
+   assignments.
+
+4.1.  Message Numbers
+
+   The Message Number is a byte value that describes the payload of a
+   packet.
+
+4.1.1.  Conventions
+
+   Protocol packets have message numbers in the range 1 to 255.  These
+   numbers are allocated as follows:
+
+      Transport layer protocol:
+
+        1 to 19    Transport layer generic (e.g., disconnect, ignore,
+                   debug, etc.)
+        20 to 29   Algorithm negotiation
+        30 to 49   Key exchange method specific (numbers can be reused
+                   for different authentication methods)
+
+      User authentication protocol:
+
+        50 to 59   User authentication generic
+        60 to 79   User authentication method specific (numbers can be
+                   reused for different authentication methods)
+
+      Connection protocol:
+
+        80 to 89   Connection protocol generic
+        90 to 127  Channel related messages
+
+      Reserved for client protocols:
+
+        128 to 191 Reserved
+
+      Local extensions:
+
+        192 to 255 Local extensions
+
+
+
+
+
+
+
+Lehtinen & Lonvick          Standards Track                     [Page 5]
+
+RFC 4250             SSH Protocol Assigned Numbers          January 2006
+
+
+4.1.2.  Initial Assignments
+
+   The following table identifies the initial assignments of the Message
+   ID values.
+
+         Message ID                            Value    Reference
+         -----------                           -----    ---------
+         SSH_MSG_DISCONNECT                       1     [SSH-TRANS]
+         SSH_MSG_IGNORE                           2     [SSH-TRANS]
+         SSH_MSG_UNIMPLEMENTED                    3     [SSH-TRANS]
+         SSH_MSG_DEBUG                            4     [SSH-TRANS]
+         SSH_MSG_SERVICE_REQUEST                  5     [SSH-TRANS]
+         SSH_MSG_SERVICE_ACCEPT                   6     [SSH-TRANS]
+         SSH_MSG_KEXINIT                         20     [SSH-TRANS]
+         SSH_MSG_NEWKEYS                         21     [SSH-TRANS]
+         SSH_MSG_USERAUTH_REQUEST                50     [SSH-USERAUTH]
+         SSH_MSG_USERAUTH_FAILURE                51     [SSH-USERAUTH]
+         SSH_MSG_USERAUTH_SUCCESS                52     [SSH-USERAUTH]
+         SSH_MSG_USERAUTH_BANNER                 53     [SSH-USERAUTH]
+         SSH_MSG_GLOBAL_REQUEST                  80     [SSH-CONNECT]
+         SSH_MSG_REQUEST_SUCCESS                 81     [SSH-CONNECT]
+         SSH_MSG_REQUEST_FAILURE                 82     [SSH-CONNECT]
+         SSH_MSG_CHANNEL_OPEN                    90     [SSH-CONNECT]
+         SSH_MSG_CHANNEL_OPEN_CONFIRMATION       91     [SSH-CONNECT]
+         SSH_MSG_CHANNEL_OPEN_FAILURE            92     [SSH-CONNECT]
+         SSH_MSG_CHANNEL_WINDOW_ADJUST           93     [SSH-CONNECT]
+         SSH_MSG_CHANNEL_DATA                    94     [SSH-CONNECT]
+         SSH_MSG_CHANNEL_EXTENDED_DATA           95     [SSH-CONNECT]
+         SSH_MSG_CHANNEL_EOF                     96     [SSH-CONNECT]
+         SSH_MSG_CHANNEL_CLOSE                   97     [SSH-CONNECT]
+         SSH_MSG_CHANNEL_REQUEST                 98     [SSH-CONNECT]
+         SSH_MSG_CHANNEL_SUCCESS                 99     [SSH-CONNECT]
+         SSH_MSG_CHANNEL_FAILURE                100     [SSH-CONNECT]
+
+4.1.3.  Future Assignments
+
+   Requests for assignments of new message numbers in the range of 1 to
+   29, 50 to 59, and 80 to 127 MUST be done through the STANDARDS ACTION
+   method, as described in [RFC2434].
+
+   The meanings of message numbers in the range of 30 to 49 are specific
+   to the key exchange method in use, and their meaning will be
+   specified by the definition of that method.
+
+
+
+
+
+
+
+
+Lehtinen & Lonvick          Standards Track                     [Page 6]
+
+RFC 4250             SSH Protocol Assigned Numbers          January 2006
+
+
+   The meanings of message numbers in the range of 60 to 79 are specific
+   to the user authentication method in use, and their meaning will be
+   specified by the definition of that method.
+
+   Requests for assignments of new message numbers in the range of 128
+   to 191 MUST be done through the IETF CONSENSUS method, as described
+   in [RFC2434].
+
+   The IANA will not control the message numbers in the range of 192
+   through 255.  This range will be left for PRIVATE USE.
+
+4.2.  Disconnection Messages Reason Codes and Descriptions
+
+   The Disconnection Message 'reason code' is a uint32 value.  The
+   associated Disconnection Message 'description' is a human-readable
+   message that describes the disconnect reason.
+
+4.2.1.  Conventions
+
+   Protocol packets containing the SSH_MSG_DISCONNECT message MUST have
+   Disconnection Message 'reason code' values in the range of 0x00000001
+   to 0xFFFFFFFF.  These are described in [SSH-TRANS].
+
+4.2.2.  Initial Assignments
+
+   The following table identifies the initial assignments of the
+   SSH_MSG_DISCONNECT 'description' and 'reason code' values.
+
+         Symbolic Name                                  reason code
+         -------------                                  -----------
+         SSH_DISCONNECT_HOST_NOT_ALLOWED_TO_CONNECT          1
+         SSH_DISCONNECT_PROTOCOL_ERROR                       2
+         SSH_DISCONNECT_KEY_EXCHANGE_FAILED                  3
+         SSH_DISCONNECT_RESERVED                             4
+         SSH_DISCONNECT_MAC_ERROR                            5
+         SSH_DISCONNECT_COMPRESSION_ERROR                    6
+         SSH_DISCONNECT_SERVICE_NOT_AVAILABLE                7
+         SSH_DISCONNECT_PROTOCOL_VERSION_NOT_SUPPORTED       8
+         SSH_DISCONNECT_HOST_KEY_NOT_VERIFIABLE              9
+         SSH_DISCONNECT_CONNECTION_LOST                     10
+         SSH_DISCONNECT_BY_APPLICATION                      11
+         SSH_DISCONNECT_TOO_MANY_CONNECTIONS                12
+         SSH_DISCONNECT_AUTH_CANCELLED_BY_USER              13
+         SSH_DISCONNECT_NO_MORE_AUTH_METHODS_AVAILABLE      14
+         SSH_DISCONNECT_ILLEGAL_USER_NAME                   15
+
+
+
+
+
+
+Lehtinen & Lonvick          Standards Track                     [Page 7]
+
+RFC 4250             SSH Protocol Assigned Numbers          January 2006
+
+
+4.2.3.  Future Assignments
+
+   Disconnection Message 'reason code' values MUST be assigned
+   sequentially.  Requests for assignments of new Disconnection Message
+   'reason code' values, and their associated Disconnection Message
+   'description' text, in the range of 0x00000010 through 0xFDFFFFFF,
+   MUST be done through the IETF CONSENSUS method, as described in
+   [RFC2434].  The IANA will not assign Disconnection Message 'reason
+   code' values in the range of 0xFE000000 through 0xFFFFFFFF.
+   Disconnection Message 'reason code' values in that range are left for
+   PRIVATE USE, as described in [RFC2434].
+
+4.3.  Channel Connection Failure Reason Codes and Descriptions
+
+   The Channel Connection Failure 'reason code' is a uint32 value.  The
+   associated Channel Connection Failure 'description' text is a human-
+   readable message that describes the channel connection failure
+   reason.  This is described in [SSH-CONNECT].
+
+4.3.1.  Conventions
+
+   Protocol packets containing the SSH_MSG_CHANNEL_OPEN_FAILURE message
+   MUST have Channel Connection Failure 'reason code' values in the
+   range of 0x00000001 to 0xFFFFFFFF.
+
+4.3.2.  Initial Assignments
+
+   The initial assignments for the 'reason code' values and
+   'description' values are given in the table below.  Note that the
+   values for the 'reason code' are given in decimal format for
+   readability, but they are actually uint32 values.
+
+         Symbolic Name                                  reason code
+         -------------                                  -----------
+         SSH_OPEN_ADMINISTRATIVELY_PROHIBITED                1
+         SSH_OPEN_CONNECT_FAILED                             2
+         SSH_OPEN_UNKNOWN_CHANNEL_TYPE                       3
+         SSH_OPEN_RESOURCE_SHORTAGE                          4
+
+4.3.3.  Future Assignments
+
+   Channel Connection Failure 'reason code' values MUST be assigned
+   sequentially.  Requests for assignments of new Channel Connection
+   Failure 'reason code' values, and their associated Channel Connection
+   Failure 'description string', in the range of 0x00000005 to
+   0xFDFFFFFF MUST be done through the IETF CONSENSUS method, as
+   described in [RFC2434].  The IANA will not assign Channel Connection
+
+
+
+
+Lehtinen & Lonvick          Standards Track                     [Page 8]
+
+RFC 4250             SSH Protocol Assigned Numbers          January 2006
+
+
+   Failure 'reason code' values in the range of 0xFE000000 to
+   0xFFFFFFFF.  Channel Connection Failure 'reason code' values in that
+   range are left for PRIVATE USE, as described in [RFC2434].
+
+4.3.4.  Notes about the PRIVATE USE Range
+
+   While it is understood that the IANA will have no control over the
+   range of 0xFE000000 to 0xFFFFFFFF, this range will be split in two
+   parts and administered by the following conventions.
+
+   o  The range of 0xFE000000 to 0xFEFFFFFF is to be used in conjunction
+      with locally assigned channels.  For example, if a channel is
+      proposed with a 'channel type' of "example_session@example.com"
+      but fails, then the server will respond with either a 'reason
+      code' assigned by the IANA (as listed above and in the range of
+      0x00000001 to 0xFDFFFFFF), or with a locally assigned value in the
+      range of 0xFE000000 to 0xFEFFFFFF.  Naturally, if the server does
+      not understand the proposed 'channel type', even if it is a
+      locally defined 'channel type', then the 'reason code' MUST be
+      0x00000003, as described above.  If the server does understand the
+      'channel type', but the channel still fails to open, then the
+      server SHOULD respond with a locally assigned 'reason code' value
+      that is consistent with the proposed local 'channel type'.  It is
+      assumed that practitioners will first attempt to use the IANA-
+      assigned 'reason code' values and then document their locally
+      assigned 'reason code' values.
+
+   o  There are no restrictions or suggestions for the range starting
+      with 0xFF.  No interoperability is expected for anything used in
+      this range.  Essentially, it is for experimentation.
+
+4.4.  Extended Channel Data Transfer data_type_code and Data
+
+   The Extended Channel Data Transfer 'data_type_code' is a uint32
+   value.  The associated Extended Channel Data Transfer 'data' is a
+   human-readable message that describes the type of data allowed to be
+   transferred in the channel.
+
+4.4.1.  Conventions
+
+   Protocol packets containing the SSH_MSG_CHANNEL_EXTENDED_DATA message
+   MUST have Extended Channel Data Transfer 'data_type_code' values in
+   the range of 0x00000001 to 0xFFFFFFFF.  This is described in
+   [SSH-CONNECT].
+
+
+
+
+
+
+
+Lehtinen & Lonvick          Standards Track                     [Page 9]
+
+RFC 4250             SSH Protocol Assigned Numbers          January 2006
+
+
+4.4.2.  Initial Assignments
+
+   The initial assignments for the 'data_type_code' values and 'data'
+   values are given in the table below.  Note that the value for the
+   'data_type_code' is given in decimal format for readability, but the
+   values are actually uint32 values.
+
+         Symbolic name                        data_type_code
+         -------------                        --------------
+         SSH_EXTENDED_DATA_STDERR                   1
+
+4.4.3.  Future Assignments
+
+   Extended Channel Data Transfer 'data_type_code' values MUST be
+   assigned sequentially.  Requests for assignments of new Extended
+   Channel Data Transfer 'data_type_code' values, and their associated
+   Extended Channel Data Transfer 'data' strings, in the range of
+   0x00000002 to 0xFDFFFFFF, MUST be done through the IETF CONSENSUS
+   method, as described in [RFC2434].  The IANA will not assign Extended
+   Channel Data Transfer 'data_type_code' values in the range of
+   0xFE000000 to 0xFFFFFFFF.  Extended Channel Data Transfer
+   'data_type_code' values in that range are left for PRIVATE USE, as
+   described in [RFC2434].
+
+4.5.  Pseudo-Terminal Encoded Terminal Modes
+
+   SSH_MSG_CHANNEL_REQUEST messages with a "pty-req" string MUST contain
+   'encoded terminal modes'.  The 'encoded terminal modes' value is a
+   byte stream of opcode-argument pairs.
+
+4.5.1.  Conventions
+
+   Protocol packets containing the SSH_MSG_CHANNEL_REQUEST message with
+   a "pty-req" string MUST contain an 'encoded terminal modes' value.
+   The opcode values consist of a single byte and are in the range of 1
+   to 255.  Opcodes 1 to 159 have a uint32 argument.  Opcodes 160 to 255
+   are not yet defined.
+
+4.5.2.  Initial Assignments
+
+   The following table identifies the initial assignments of the opcode
+   values that are used in the 'encoded terminal modes' value.
+
+
+
+
+
+
+
+
+
+Lehtinen & Lonvick          Standards Track                    [Page 10]
+
+RFC 4250             SSH Protocol Assigned Numbers          January 2006
+
+
+         opcode  mnemonic       description
+         ------  --------       -----------
+         0     TTY_OP_END  Indicates end of options.
+         1     VINTR       Interrupt character; 255 if none.  Similarly
+                            for the other characters.  Not all of these
+                            characters are supported on all systems.
+         2     VQUIT       The quit character (sends SIGQUIT signal on
+                            POSIX systems).
+         3     VERASE      Erase the character to left of the cursor.
+         4     VKILL       Kill the current input line.
+         5     VEOF        End-of-file character (sends EOF from the
+                            terminal).
+         6     VEOL        End-of-line character in addition to
+                            carriage return and/or linefeed.
+         7     VEOL2       Additional end-of-line character.
+         8     VSTART      Continues paused output (normally
+                            control-Q).
+         9     VSTOP       Pauses output (normally control-S).
+         10    VSUSP       Suspends the current program.
+         11    VDSUSP      Another suspend character.
+         12    VREPRINT    Reprints the current input line.
+         13    VWERASE     Erases a word left of cursor.
+         14    VLNEXT      Enter the next character typed literally,
+                            even if it is a special character
+         15    VFLUSH      Character to flush output.
+         16    VSWTCH      Switch to a different shell layer.
+         17    VSTATUS     Prints system status line (load, command,
+                            pid, etc).
+         18    VDISCARD    Toggles the flushing of terminal output.
+         30    IGNPAR      The ignore parity flag.  The parameter
+                            SHOULD be 0 if this flag is FALSE,
+                            and 1 if it is TRUE.
+         31    PARMRK      Mark parity and framing errors.
+         32    INPCK       Enable checking of parity errors.
+         33    ISTRIP      Strip 8th bit off characters.
+         34    INLCR       Map NL into CR on input.
+         35    IGNCR       Ignore CR on input.
+         36    ICRNL       Map CR to NL on input.
+         37    IUCLC       Translate uppercase characters to
+                            lowercase.
+         38    IXON        Enable output flow control.
+         39    IXANY       Any char will restart after stop.
+         40    IXOFF       Enable input flow control.
+         41    IMAXBEL     Ring bell on input queue full.
+         50    ISIG        Enable signals INTR, QUIT, [D]SUSP.
+         51    ICANON      Canonicalize input lines.
+
+
+
+
+
+Lehtinen & Lonvick          Standards Track                    [Page 11]
+
+RFC 4250             SSH Protocol Assigned Numbers          January 2006
+
+
+         52    XCASE       Enable input and output of uppercase
+                            characters by preceding their lowercase
+                            equivalents with "\".
+         53    ECHO        Enable echoing.
+         54    ECHOE       Visually erase chars.
+         55    ECHOK       Kill character discards current line.
+         56    ECHONL      Echo NL even if ECHO is off.
+         57    NOFLSH      Don't flush after interrupt.
+         58    TOSTOP      Stop background jobs from output.
+         59    IEXTEN      Enable extensions.
+         60    ECHOCTL     Echo control characters as ^(Char).
+         61    ECHOKE      Visual erase for line kill.
+         62    PENDIN      Retype pending input.
+         70    OPOST       Enable output processing.
+         71    OLCUC       Convert lowercase to uppercase.
+         72    ONLCR       Map NL to CR-NL.
+         73    OCRNL       Translate carriage return to newline
+                            (output).
+         74    ONOCR       Translate newline to carriage
+                            return-newline (output).
+         75    ONLRET      Newline performs a carriage return
+                            (output).
+         90    CS7         7 bit mode.
+         91    CS8         8 bit mode.
+         92    PARENB      Parity enable.
+         93    PARODD      Odd parity, else even.
+
+         128 TTY_OP_ISPEED  Specifies the input baud rate in
+                             bits per second.
+         129 TTY_OP_OSPEED  Specifies the output baud rate in
+                             bits per second.
+
+4.5.3.  Future Assignments
+
+   Requests for assignments of new opcodes and their associated
+   arguments MUST be done through the IETF CONSENSUS method, as
+   described in [RFC2434].
+
+4.6.  Names
+
+   In the following sections, the values for the name spaces are
+   textual.  The conventions and instructions to the IANA for future
+   assignments are given in this section.  The initial assignments are
+   given in their respective sections.
+
+
+
+
+
+
+
+Lehtinen & Lonvick          Standards Track                    [Page 12]
+
+RFC 4250             SSH Protocol Assigned Numbers          January 2006
+
+
+4.6.1.  Conventions for Names
+
+   All names registered by the IANA in the following sections MUST be
+   printable US-ASCII strings, and MUST NOT contain the characters at-
+   sign ("@"), comma (","), whitespace, control characters (ASCII codes
+   32 or less), or the ASCII code 127 (DEL).  Names are case-sensitive,
+   and MUST NOT be longer than 64 characters.
+
+   A provision is made here for locally extensible names.  The IANA will
+   not register, and will not control, names with the at-sign in them.
+
+   Names with the at-sign in them will have the format of
+   "name@domainname" (without the double quotes) where the part
+   preceding the at-sign is the name.  The format of the part preceding
+   the at-sign is not specified; however, these names MUST be printable
+   US-ASCII strings, and MUST NOT contain the comma character (","),
+   whitespace, control characters (ASCII codes 32 or less), or the ASCII
+   code 127 (DEL).  They MUST have only a single at-sign in them.  The
+   part following the at-sign MUST be a valid, fully qualified internet
+   domain name [RFC1034] controlled by the person or organization
+   defining the name.  Names are case-sensitive, and MUST NOT be longer
+   than 64 characters.  It is up to each domain how it manages its local
+   namespace.  It has been noted that these names resemble STD 11
+   [RFC0822] email addresses.  This is purely coincidental and has
+   nothing to do with STD 11 [RFC0822].  An example of a locally defined
+   name is "ourcipher-cbc@example.com" (without the double quotes).
+
+4.6.2.  Future Assignments of Names
+
+   Requests for assignments of new names MUST be done through the IETF
+   CONSENSUS method, as described in [RFC2434].
+
+4.7.  Service Names
+
+   The 'service name' is used to describe a protocol layer.  The
+   following table lists the initial assignments of the 'service name'
+   values.
+
+         Service Name                  Reference
+         -------------                 ---------
+         ssh-userauth                  [SSH-USERAUTH]
+         ssh-connection                [SSH-CONNECT]
+
+
+
+
+
+
+
+
+
+Lehtinen & Lonvick          Standards Track                    [Page 13]
+
+RFC 4250             SSH Protocol Assigned Numbers          January 2006
+
+
+4.8.  Authentication Method Names
+
+   The Authentication Method Name is used to describe an authentication
+   method for the "ssh-userauth" service [SSH-USERAUTH].  The following
+   table identifies the initial assignments of the Authentication Method
+   Names.
+
+         Method Name                   Reference
+         ------------                  ---------
+         publickey                     [SSH-USERAUTH, Section 7]
+         password                      [SSH-USERAUTH, Section 8]
+         hostbased                     [SSH-USERAUTH, Section 9]
+         none                          [SSH-USERAUTH, Section 5.2]
+
+4.9.  Connection Protocol Assigned Names
+
+   The following table lists the initial assignments to the Connection
+   Protocol Type and Request names.
+
+4.9.1.  Connection Protocol Channel Types
+
+   The following table lists the initial assignments of the Connection
+   Protocol Channel Types.
+
+         Channel type                  Reference
+         ------------                  ---------
+         session                       [SSH-CONNECT, Section 6.1]
+         x11                           [SSH-CONNECT, Section 6.3.2]
+         forwarded-tcpip               [SSH-CONNECT, Section 7.2]
+         direct-tcpip                  [SSH-CONNECT, Section 7.2]
+
+4.9.2.  Connection Protocol Global Request Names
+
+   The following table lists the initial assignments of the Connection
+   Protocol Global Request Names.
+
+         Request type                  Reference
+         ------------                  ---------
+         tcpip-forward                 [SSH-CONNECT, Section 7.1]
+         cancel-tcpip-forward          [SSH-CONNECT, Section 7.1]
+
+
+
+
+
+
+
+
+
+
+
+Lehtinen & Lonvick          Standards Track                    [Page 14]
+
+RFC 4250             SSH Protocol Assigned Numbers          January 2006
+
+
+4.9.3.  Connection Protocol Channel Request Names
+
+   The following table lists the initial assignments of the Connection
+   Protocol Channel Request Names.
+
+         Request type                  Reference
+         ------------                  ---------
+         pty-req                       [SSH-CONNECT, Section 6.2]
+         x11-req                       [SSH-CONNECT, Section 6.3.1]
+         env                           [SSH-CONNECT, Section 6.4]
+         shell                         [SSH-CONNECT, Section 6.5]
+         exec                          [SSH-CONNECT, Section 6.5]
+         subsystem                     [SSH-CONNECT, Section 6.5]
+         window-change                 [SSH-CONNECT, Section 6.7]
+         xon-xoff                      [SSH-CONNECT, Section 6.8]
+         signal                        [SSH-CONNECT, Section 6.9]
+         exit-status                   [SSH-CONNECT, Section 6.10]
+         exit-signal                   [SSH-CONNECT, Section 6.10]
+
+4.9.4.  Initial Assignment of Signal Names
+
+   The following table lists the initial assignments of the Signal
+   Names.
+
+         Signal                        Reference
+         ------                        ---------
+          ABRT                         [SSH-CONNECT]
+          ALRM                         [SSH-CONNECT]
+          FPE                          [SSH-CONNECT]
+          HUP                          [SSH-CONNECT]
+          ILL                          [SSH-CONNECT]
+          INT                          [SSH-CONNECT]
+          KILL                         [SSH-CONNECT]
+          PIPE                         [SSH-CONNECT]
+          QUIT                         [SSH-CONNECT]
+          SEGV                         [SSH-CONNECT]
+          TERM                         [SSH-CONNECT]
+          USR1                         [SSH-CONNECT]
+          USR2                         [SSH-CONNECT]
+
+4.9.5.  Connection Protocol Subsystem Names
+
+   There are no initial assignments of the Connection Protocol Subsystem
+   Names.
+
+
+
+
+
+
+
+Lehtinen & Lonvick          Standards Track                    [Page 15]
+
+RFC 4250             SSH Protocol Assigned Numbers          January 2006
+
+
+4.10.  Key Exchange Method Names
+
+   The name "diffie-hellman-group1-sha1" is used for a key exchange
+   method using an Oakley group, as defined in [RFC2409].  SSH maintains
+   its own group identifier space, which is logically distinct from
+   Oakley [RFC2412] and IKE; however, for one additional group, the
+   Working Group adopted the number assigned by [RFC3526], using
+   "diffie-hellman-group14-sha1" for the name of the second defined
+   group.  Implementations should treat these names as opaque
+   identifiers and should not assume any relationship between the groups
+   used by SSH and the groups defined for IKE.
+
+   The following table identifies the initial assignments of the key
+   exchange methods.
+
+         Method name                          Reference
+         ------------                         ---------
+         diffie-hellman-group1-sha1     [SSH-TRANS, Section 8.1]
+         diffie-hellman-group14-sha1    [SSH-TRANS, Section 8.2]
+
+4.11.  Assigned Algorithm Names
+
+4.11.1.  Encryption Algorithm Names
+
+   The following table identifies the initial assignment of the
+   Encryption Algorithm Names.
+
+         Encryption Algorithm Name                   Reference
+         -------------------------                   ---------
+         3des-cbc                           [SSH-TRANS, Section 6.3]
+         blowfish-cbc                       [SSH-TRANS, Section 6.3]
+         twofish256-cbc                     [SSH-TRANS, Section 6.3]
+         twofish-cbc                        [SSH-TRANS, Section 6.3]
+         twofish192-cbc                     [SSH-TRANS, Section 6.3]
+         twofish128-cbc                     [SSH-TRANS, Section 6.3]
+         aes256-cbc                         [SSH-TRANS, Section 6.3]
+         aes192-cbc                         [SSH-TRANS, Section 6.3]
+         aes128-cbc                         [SSH-TRANS, Section 6.3]
+         serpent256-cbc                     [SSH-TRANS, Section 6.3]
+         serpent192-cbc                     [SSH-TRANS, Section 6.3]
+         serpent128-cbc                     [SSH-TRANS, Section 6.3]
+         arcfour                            [SSH-TRANS, Section 6.3]
+         idea-cbc                           [SSH-TRANS, Section 6.3]
+         cast128-cbc                        [SSH-TRANS, Section 6.3]
+         none                               [SSH-TRANS, Section 6.3]
+         des-cbc                            [FIPS-46-3] HISTORIC; See
+                                              page 4 of [FIPS-46-3]
+
+
+
+
+Lehtinen & Lonvick          Standards Track                    [Page 16]
+
+RFC 4250             SSH Protocol Assigned Numbers          January 2006
+
+
+4.11.2.  MAC Algorithm Names
+
+   The following table identifies the initial assignments of the MAC
+   Algorithm Names.
+
+         MAC Algorithm Name                      Reference
+         ------------------                      ---------
+         hmac-sha1                         [SSH-TRANS, Section 6.4]
+         hmac-sha1-96                      [SSH-TRANS, Section 6.4]
+         hmac-md5                          [SSH-TRANS, Section 6.4]
+         hmac-md5-96                       [SSH-TRANS, Section 6.4]
+         none                              [SSH-TRANS, Section 6.4]
+
+4.11.3.  Public Key Algorithm Names
+
+   The following table identifies the initial assignments of the Public
+   Key Algorithm names.
+
+         Public Key Algorithm Name                 Reference
+         -------------------------                 ---------
+         ssh-dss                            [SSH-TRANS, Section 6.6]
+         ssh-rsa                            [SSH-TRANS, Section 6.6]
+         pgp-sign-rsa                       [SSH-TRANS, Section 6.6]
+         pgp-sign-dss                       [SSH-TRANS, Section 6.6]
+
+4.11.4.  Compression Algorithm Names
+
+   The following table identifies the initial assignments of the
+   Compression Algorithm names.
+
+         Compression Algorithm Name                Reference
+         --------------------------                ---------
+         none                               [SSH-TRANS, Section 6.2]
+         zlib                               [SSH-TRANS, Section 6.2]
+
+5.  Security Considerations
+
+   This protocol provides a secure encrypted channel over an insecure
+   network.
+
+   Full security considerations for this protocol are provided in
+   [SSH-ARCH].
+
+
+
+
+
+
+
+
+
+Lehtinen & Lonvick          Standards Track                    [Page 17]
+
+RFC 4250             SSH Protocol Assigned Numbers          January 2006
+
+
+6.  References
+
+6.1.  Normative References
+
+   [SSH-ARCH]     Ylonen, T. and C. Lonvick, Ed., "The Secure Shell
+                  (SSH) Protocol Architecture", RFC 4251, January 2006.
+
+   [SSH-TRANS]    Ylonen, T. and C. Lonvick, Ed., "The Secure Shell
+                  (SSH) Transport Layer Protocol", RFC 4253, January
+                  2006.
+
+   [SSH-USERAUTH] Ylonen, T. and C. Lonvick, Ed., "The Secure Shell
+                  (SSH) Authentication Protocol", RFC 4252, January
+                  2006.
+
+   [SSH-CONNECT]  Ylonen, T. and C. Lonvick, Ed., "The Secure Shell
+                  (SSH) Connection Protocol", RFC 4254, January 2006.
+
+   [RFC2119]      Bradner, S., "Key words for use in RFCs to Indicate
+                  Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC2409]      Harkins, D. and D. Carrel, "The Internet Key Exchange
+                  (IKE)", RFC 2409, November 1998.
+
+   [RFC2434]      Narten, T. and H. Alvestrand, "Guidelines for Writing
+                  an IANA Considerations Section in RFCs", BCP 26, RFC
+                  2434, October 1998.
+
+   [RFC3526]      Kivinen, T. and M. Kojo, "More Modular Exponential
+                  (MODP) Diffie-Hellman groups for Internet Key Exchange
+                  (IKE)", RFC 3526, May 2003.
+
+6.2.  Informative References
+
+   [RFC0822]      Crocker, D., "Standard for the format of ARPA Internet
+                  text messages", STD 11, RFC 822, August 1982.
+
+   [RFC1034]      Mockapetris, P., "Domain names - concepts and
+                  facilities", STD 13, RFC 1034, November 1987.
+
+   [RFC2412]      Orman, H., "The OAKLEY Key Determination Protocol",
+                  RFC 2412, November 1998.
+
+   [FIPS-46-3]    US National Institute of Standards and Technology,
+                  "Data Encryption Standard (DES)", Federal Information
+                  Processing Standards Publication 46-3, October 1999.
+
+
+
+
+
+Lehtinen & Lonvick          Standards Track                    [Page 18]
+
+RFC 4250             SSH Protocol Assigned Numbers          January 2006
+
+
+Authors' Addresses
+
+   Sami Lehtinen
+   SSH Communications Security Corp
+   Valimotie 17
+   00380 Helsinki
+   Finland
+
+   EMail: sjl@ssh.com
+
+
+   Chris Lonvick (editor)
+   Cisco Systems, Inc.
+   12515 Research Blvd.
+   Austin  78759
+   USA
+
+   EMail: clonvick@cisco.com
+
+Trademark Notice
+
+   "ssh" is a registered trademark in the United States and/or other
+   countries.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Lehtinen & Lonvick          Standards Track                    [Page 19]
+
+RFC 4250             SSH Protocol Assigned Numbers          January 2006
+
+
+Full Copyright Statement
+
+   Copyright (C) The Internet Society (2006).
+
+   This document is subject to the rights, licenses and restrictions
+   contained in BCP 78, and except as set forth therein, the authors
+   retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY AND THE INTERNET
+   ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES, EXPRESS OR IMPLIED,
+   INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE
+   INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+   WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the procedures with respect to rights in RFC documents can be
+   found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at
+   ietf-ipr@ietf.org.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is provided by the IETF
+   Administrative Support Activity (IASA).
+
+
+
+
+
+
+
+Lehtinen & Lonvick          Standards Track                    [Page 20]
+
+
+ Warning: User-Agent string does not contain "Lynx" or "L_y_n_x"!

--- a/rustyssh/src/api.rs
+++ b/rustyssh/src/api.rs
@@ -62,7 +62,11 @@ impl ReadSSH for Vec<String> {
         let name_list = String::from_utf8(name_list_bytes)
             .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidData, "Invalid UTF-8"))?;
 
-        Ok(name_list.split(',').map(String::from).collect())
+        if name_list.is_empty() && length == 0 { // Ensure it was an intentionally empty list
+            Ok(Vec::new())
+        } else {
+            Ok(name_list.split(',').map(String::from).collect())
+        }
     }
 }
 

--- a/rustyssh/src/lib.rs
+++ b/rustyssh/src/lib.rs
@@ -1,2 +1,5 @@
 mod api;
 mod msg;
+
+#[cfg(test)]
+mod tests;

--- a/rustyssh/src/msg.rs
+++ b/rustyssh/src/msg.rs
@@ -11,15 +11,41 @@ pub fn read_next_message<R: std::io::Read>(mut reader: R) -> Result<SSHMsg, std:
 
     match magic {
         MsgDisconnect::MAGIC => MsgDisconnect::read_ssh(reader).map(SSHMsg::Disconnect),
+        MsgIgnore::MAGIC => MsgIgnore::read_ssh(reader).map(SSHMsg::Ignore),
+        MsgUnimplemented::MAGIC => MsgUnimplemented::read_ssh(reader).map(SSHMsg::Unimplemented),
+        MsgDebug::MAGIC => MsgDebug::read_ssh(reader).map(SSHMsg::Debug),
+        MsgServiceRequest::MAGIC => MsgServiceRequest::read_ssh(reader).map(SSHMsg::ServiceRequest),
+        MsgServiceAccept::MAGIC => MsgServiceAccept::read_ssh(reader).map(SSHMsg::ServiceAccept),
         MsgKexInit::MAGIC => MsgKexInit::read_ssh(reader).map(SSHMsg::KexInit),
+        MsgNewKeys::MAGIC => MsgNewKeys::read_ssh(reader).map(SSHMsg::NewKeys),
+        MsgKexECDHInit::MAGIC => MsgKexECDHInit::read_ssh(reader).map(SSHMsg::KexECDHInit),
+        MsgKexECDHReply::MAGIC => MsgKexECDHReply::read_ssh(reader).map(SSHMsg::KexECDHReply),
+        MsgUserauthRequest::MAGIC => MsgUserauthRequest::read_ssh(reader).map(SSHMsg::UserauthRequest),
+        MsgUserauthFailure::MAGIC => MsgUserauthFailure::read_ssh(reader).map(SSHMsg::UserauthFailure),
+        MsgUserauthSuccess::MAGIC => MsgUserauthSuccess::read_ssh(reader).map(SSHMsg::UserauthSuccess),
+        MsgUserauthBanner::MAGIC => MsgUserauthBanner::read_ssh(reader).map(SSHMsg::UserauthBanner),
+        MsgGlobalRequest::MAGIC => MsgGlobalRequest::read_ssh(reader).map(SSHMsg::GlobalRequest),
+        MsgRequestSuccess::MAGIC => MsgRequestSuccess::read_ssh(reader).map(SSHMsg::RequestSuccess),
+        MsgRequestFailure::MAGIC => MsgRequestFailure::read_ssh(reader).map(SSHMsg::RequestFailure),
+        MsgChannelOpen::MAGIC => MsgChannelOpen::read_ssh(reader).map(SSHMsg::ChannelOpen),
+        MsgChannelOpenConfirmation::MAGIC => MsgChannelOpenConfirmation::read_ssh(reader).map(SSHMsg::ChannelOpenConfirmation),
+        MsgChannelOpenFailure::MAGIC => MsgChannelOpenFailure::read_ssh(reader).map(SSHMsg::ChannelOpenFailure),
+        MsgChannelWindowAdjust::MAGIC => MsgChannelWindowAdjust::read_ssh(reader).map(SSHMsg::ChannelWindowAdjust),
+        MsgChannelData::MAGIC => MsgChannelData::read_ssh(reader).map(SSHMsg::ChannelData),
+        MsgChannelExtendedData::MAGIC => MsgChannelExtendedData::read_ssh(reader).map(SSHMsg::ChannelExtendedData),
+        MsgChannelEof::MAGIC => MsgChannelEof::read_ssh(reader).map(SSHMsg::ChannelEof),
+        MsgChannelClose::MAGIC => MsgChannelClose::read_ssh(reader).map(SSHMsg::ChannelClose),
+        MsgChannelRequest::MAGIC => MsgChannelRequest::read_ssh(reader).map(SSHMsg::ChannelRequest),
+        MsgChannelSuccess::MAGIC => MsgChannelSuccess::read_ssh(reader).map(SSHMsg::ChannelSuccess),
+        MsgChannelFailure::MAGIC => MsgChannelFailure::read_ssh(reader).map(SSHMsg::ChannelFailure),
         _ => Err(std::io::Error::new(
             std::io::ErrorKind::InvalidData,
-            "Unknown magic number",
+            format!("Unknown magic number: {}", magic),
         )),
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Copy, Clone)]
 #[allow(dead_code)]
 pub enum Magic {
     Disconnect = 1,               // byte       SSH_MSG_DISCONNECT
@@ -53,35 +79,36 @@ pub enum Magic {
 }
 
 // Enums
-#[repr(u8)]
-#[derive(Debug, PartialEq, ReadSSH, WriteSSH)]
+#[repr(u32)] // RFC 4250 says reason code is uint32
+#[derive(Debug, PartialEq, ReadSSH, WriteSSH, Clone, Copy)] // Added Clone, Copy
 pub enum DisconnectCode {
-    HostNotAllowedToConnect = 1,     // byte       SSH_MSG_DISCONNECT
-    ProtocolError = 2,               // byte       SSH_MSG_DISCONNECT
-    KeyExchangeFailed = 3,           // byte       SSH_MSG_DISCONNECT
-    Reserved = 4,                    // byte       SSH_MSG_DISCONNECT
-    MacError = 5,                    // byte       SSH_MSG_DISCONNECT
-    CompressionError = 6,            // byte       SSH_MSG_DISCONNECT
-    ServiceNotAvailable = 7,         // byte       SSH_MSG_DISCONNECT
-    ProtocolVersionNotSupported = 8, // byte       SSH_MSG_DISCONNECT
-    HostKeyNotVerifiable = 9,        // byte       SSH_MSG_DISCONNECT
-    ConnectionLost = 10,             // byte       SSH_MSG_DISCONNECT
-    ByApplication = 11,              // byte       SSH_MSG_DISCONNECT
-    TooManyConnections = 12,         // byte       SSH_MSG_DISCONNECT
-    AuthCancelledByUser = 13,        // byte       SSH_MSG_DISCONNECT
-    NoMoreAuthMethodsAvailable = 14, // byte       SSH_MSG_DISCONNECT
-    IllegalUserName = 15,            // byte       SSH_MSG_DISCONNECT
+    HostNotAllowedToConnect = 1,     // SSH_DISCONNECT_HOST_NOT_ALLOWED_TO_CONNECT
+    ProtocolError = 2,               // SSH_DISCONNECT_PROTOCOL_ERROR
+    KeyExchangeFailed = 3,           // SSH_DISCONNECT_KEY_EXCHANGE_FAILED
+    Reserved = 4,                    // SSH_DISCONNECT_RESERVED
+    MacError = 5,                    // SSH_DISCONNECT_MAC_ERROR
+    CompressionError = 6,            // SSH_DISCONNECT_COMPRESSION_ERROR
+    ServiceNotAvailable = 7,         // SSH_DISCONNECT_SERVICE_NOT_AVAILABLE
+    ProtocolVersionNotSupported = 8, // SSH_DISCONNECT_PROTOCOL_VERSION_NOT_SUPPORTED
+    HostKeyNotVerifiable = 9,        // SSH_DISCONNECT_HOST_KEY_NOT_VERIFIABLE
+    ConnectionLost = 10,             // SSH_DISCONNECT_CONNECTION_LOST
+    ByApplication = 11,              // SSH_DISCONNECT_BY_APPLICATION
+    TooManyConnections = 12,         // SSH_DISCONNECT_TOO_MANY_CONNECTIONS
+    AuthCancelledByUser = 13,        // SSH_DISCONNECT_AUTH_CANCELLED_BY_USER
+    NoMoreAuthMethodsAvailable = 14, // SSH_DISCONNECT_NO_MORE_AUTH_METHODS_AVAILABLE
+    IllegalUserName = 15,            // SSH_DISCONNECT_ILLEGAL_USER_NAME
 }
 
-#[derive(Debug, PartialEq, ReadSSH, WriteSSH)]
-pub enum ChannelOpenFailure {
-    AdministrativelyProhibited = 1, // byte     SSH_MSG_CHANNEL_OPEN_FAILURE
-    ConnectFailed = 2,              // byte     SSH_MSG_CHANNEL_OPEN_FAILURE
-    UnknownChannelType = 3,         // byte     SSH_MSG_CHANNEL_OPEN_FAILURE
-    ResourceShortage = 4,           // byte     SSH_MSG_CHANNEL_OPEN_FAILURE
+#[repr(u32)] // RFC 4250 says reason code is uint32
+#[derive(Debug, PartialEq, ReadSSH, WriteSSH, Clone, Copy)] // Added Clone, Copy
+pub enum ChannelOpenFailureReasonCode {
+    AdministrativelyProhibited = 1, // SSH_OPEN_ADMINISTRATIVELY_PROHIBITED
+    ConnectFailed = 2,              // SSH_OPEN_CONNECT_FAILED
+    UnknownChannelType = 3,         // SSH_OPEN_UNKNOWN_CHANNEL_TYPE
+    ResourceShortage = 4,           // SSH_OPEN_RESOURCE_SHORTAGE
 }
 
-#[derive(Debug, PartialEq, ReadSSH, WriteSSH)]
+#[derive(Debug, PartialEq, ReadSSH, WriteSSH, Clone, Copy)] // Added Clone, Copy
 #[allow(non_camel_case_types, non_snake_case)]
 pub enum PseudoTerminalModes {
     TTY_OP_END = 0,      // Indicates end of options.
@@ -142,14 +169,14 @@ pub enum PseudoTerminalModes {
     TTY_OP_OSPEED = 129, // Specifies the output baud rate in bits per second.
 }
 
-#[derive(Debug, PartialEq, ReadSSH, WriteSSH)]
+#[derive(Debug, PartialEq, ReadSSH, WriteSSH, Clone)] // Added Clone
 #[allow(non_camel_case_types, non_snake_case)]
 pub enum Service {
     ssh__userauth,
     ssh__connection,
 }
 
-#[derive(Debug, PartialEq, ReadSSH, WriteSSH)]
+#[derive(Debug, PartialEq, ReadSSH, WriteSSH, Clone)] // Added Clone
 #[allow(non_camel_case_types, non_snake_case)]
 pub enum AuthenticationMethod {
     publickey,
@@ -158,7 +185,7 @@ pub enum AuthenticationMethod {
     none,
 }
 
-#[derive(Debug, PartialEq, ReadSSH, WriteSSH)]
+#[derive(Debug, PartialEq, ReadSSH, WriteSSH, Clone)] // Added Clone
 #[allow(non_camel_case_types, non_snake_case)]
 pub enum ConnectionProtocolChannelType {
     session,
@@ -167,14 +194,14 @@ pub enum ConnectionProtocolChannelType {
     direct__tcpip,
 }
 
-#[derive(Debug, PartialEq, ReadSSH, WriteSSH)]
+#[derive(Debug, PartialEq, ReadSSH, WriteSSH, Clone)] // Added Clone
 #[allow(non_camel_case_types, non_snake_case)]
 pub enum ConnectionProtocolRequestType {
     tcpip__forward,
     cancel__tcpip__forward,
 }
 
-#[derive(Debug, PartialEq, ReadSSH, WriteSSH)]
+#[derive(Debug, PartialEq, ReadSSH, WriteSSH, Clone)] // Added Clone
 #[allow(non_camel_case_types, non_snake_case)]
 pub enum ConnectionProtocolChannelRequestName {
     pty__req,
@@ -190,7 +217,7 @@ pub enum ConnectionProtocolChannelRequestName {
     exit__signal,
 }
 
-#[derive(Debug, PartialEq, ReadSSH, WriteSSH)]
+#[derive(Debug, PartialEq, ReadSSH, WriteSSH, Clone, Copy)] // Added Clone, Copy
 #[allow(non_camel_case_types, non_snake_case)]
 pub enum SignalName {
     ABRT,
@@ -208,14 +235,14 @@ pub enum SignalName {
     USR2,
 }
 
-#[derive(Debug, PartialEq, ReadSSH, WriteSSH)]
+#[derive(Debug, PartialEq, ReadSSH, WriteSSH, Clone)] // Added Clone
 #[allow(non_camel_case_types, non_snake_case)]
 pub enum KeyExchangeMethod {
     ecdh__sha2__nistp256,
     Unknown(String),
 }
 
-#[derive(Debug, PartialEq, ReadSSH, WriteSSH)]
+#[derive(Debug, PartialEq, ReadSSH, WriteSSH, Clone)] // Added Clone
 #[allow(non_camel_case_types, non_snake_case)]
 pub enum EncryptionAlgorithm {
     aes128__ctr,
@@ -223,7 +250,7 @@ pub enum EncryptionAlgorithm {
     Unknown(String),
 }
 
-#[derive(Debug, PartialEq, ReadSSH, WriteSSH)]
+#[derive(Debug, PartialEq, ReadSSH, WriteSSH, Clone)] // Added Clone
 #[allow(non_camel_case_types, non_snake_case)]
 pub enum MACAlgorithm {
     hmac__sha1,
@@ -232,7 +259,7 @@ pub enum MACAlgorithm {
     Unknown(String),
 }
 
-#[derive(Debug, PartialEq, ReadSSH, WriteSSH)]
+#[derive(Debug, PartialEq, ReadSSH, WriteSSH, Clone)] // Added Clone
 #[allow(non_camel_case_types, non_snake_case)]
 pub enum PublicKeyAlgorithm {
     ssh__rsa,
@@ -240,7 +267,7 @@ pub enum PublicKeyAlgorithm {
     Unknown(String),
 }
 
-#[derive(Debug, PartialEq, ReadSSH, WriteSSH)]
+#[derive(Debug, PartialEq, ReadSSH, WriteSSH, Clone)] // Added Clone
 #[allow(non_camel_case_types, non_snake_case)]
 pub enum CompressionAlgorithm {
     zlib,
@@ -249,7 +276,7 @@ pub enum CompressionAlgorithm {
 }
 
 // Structs
-#[derive(Debug, PartialEq, ReadSSH, WriteSSH)]
+#[derive(Debug, PartialEq, ReadSSH, WriteSSH, Clone)] // Added Clone
 pub struct MsgDisconnect {
     pub code: DisconnectCode, // uint32    reason code
     pub description: String,  // string    description in ISO__10646 UTF__8 encoding [RFC3629]
@@ -260,7 +287,7 @@ impl SSHMagic for MsgDisconnect {
     const MAGIC: u8 = Magic::Disconnect as u8;
 }
 
-#[derive(Debug, PartialEq, ReadSSH, WriteSSH)]
+#[derive(Debug, PartialEq, ReadSSH, WriteSSH, Clone)] // Added Clone
 pub struct MsgIgnore {
     pub data: String, // string    data
 }
@@ -269,7 +296,7 @@ impl SSHMagic for MsgIgnore {
     const MAGIC: u8 = Magic::Ignore as u8;
 }
 
-#[derive(Debug, PartialEq, ReadSSH, WriteSSH)]
+#[derive(Debug, PartialEq, ReadSSH, WriteSSH, Clone)] // Added Clone
 pub struct MsgUnimplemented {
     pub packet_sequence_number: u32, // uint32    packet sequence number of rejected message
 }
@@ -278,7 +305,7 @@ impl SSHMagic for MsgUnimplemented {
     const MAGIC: u8 = Magic::Unimplemented as u8;
 }
 
-#[derive(Debug, PartialEq, ReadSSH, WriteSSH)]
+#[derive(Debug, PartialEq, ReadSSH, WriteSSH, Clone)] // Added Clone
 pub struct MsgDebug {
     pub always_display: bool, // boolean   always_display
     pub message: String,      // string    message in ISO__10646 UTF__8 encoding [RFC3629]
@@ -307,7 +334,7 @@ impl SSHMagic for MsgServiceAccept {
     const MAGIC: u8 = Magic::ServiceAccept as u8;
 }
 
-#[derive(Debug, PartialEq, ReadSSH, WriteSSH)]
+#[derive(Debug, PartialEq, ReadSSH, WriteSSH, Clone)] // Added Clone
 pub struct MsgKexInit {
     pub cookie: [u8; 16],            // byte[16]     cookie (random bytes)
     pub kex_algorithms: Vec<String>, // name-list    kex_algorithms
@@ -328,7 +355,7 @@ impl SSHMagic for MsgKexInit {
     const MAGIC: u8 = Magic::KexInit as u8;
 }
 
-#[derive(Debug, PartialEq, ReadSSH, WriteSSH)]
+#[derive(Debug, PartialEq, ReadSSH, WriteSSH, Clone, Copy)] // Added Clone, Copy
 pub struct MsgNewKeys {}
 
 impl SSHMagic for MsgNewKeys {
@@ -355,7 +382,184 @@ impl SSHMagic for MsgKexECDHReply {
     const MAGIC: u8 = Magic::KexECDHReply as u8;
 }
 
-#[derive(Debug)]
+// User Authentication Protocol Messages (RFC 4252)
+
+#[derive(Debug, PartialEq, ReadSSH, WriteSSH)]
+pub struct MsgUserauthRequest { // Placeholder
+    pub user_name: String,
+    pub service_name: String,
+    pub method_name: String,
+    // Method-specific fields omitted for now
+}
+impl SSHMagic for MsgUserauthRequest {
+    const MAGIC: u8 = Magic::UserauthRequest as u8;
+}
+
+#[derive(Debug, PartialEq, ReadSSH, WriteSSH)]
+pub struct MsgUserauthFailure { // Placeholder
+    pub authentications_that_can_continue: Vec<String>,
+    pub partial_success: bool,
+}
+impl SSHMagic for MsgUserauthFailure {
+    const MAGIC: u8 = Magic::UserauthFailure as u8;
+}
+
+#[derive(Debug, PartialEq, ReadSSH, WriteSSH)]
+pub struct MsgUserauthSuccess { // Placeholder
+     // No fields for this message as per RFC 4252, Section 5.1
+     // pub data: Vec<u8>, // Replace with actual fields later
+}
+impl SSHMagic for MsgUserauthSuccess {
+    const MAGIC: u8 = Magic::UserauthSuccess as u8;
+}
+
+#[derive(Debug, PartialEq, ReadSSH, WriteSSH)]
+pub struct MsgUserauthBanner { // Placeholder
+    pub message: String,
+    pub language_tag: String,
+}
+impl SSHMagic for MsgUserauthBanner {
+    const MAGIC: u8 = Magic::UserauthBanner as u8;
+}
+
+// Connection Protocol Messages (RFC 4254)
+
+#[derive(Debug, PartialEq, ReadSSH, WriteSSH)]
+pub struct MsgGlobalRequest { // Placeholder
+    pub request_name: String,
+    pub want_reply: bool,
+    // Request-specific data omitted for now
+}
+impl SSHMagic for MsgGlobalRequest {
+    const MAGIC: u8 = Magic::GlobalRequest as u8;
+}
+
+#[derive(Debug, PartialEq, ReadSSH, WriteSSH)]
+pub struct MsgRequestSuccess { // Placeholder
+    // Port number for tcpip-forward, or other request-specific data
+    pub data: String, // Changed from Vec<u8>
+}
+impl SSHMagic for MsgRequestSuccess {
+    const MAGIC: u8 = Magic::RequestSuccess as u8;
+}
+
+#[derive(Debug, PartialEq, ReadSSH, WriteSSH)]
+pub struct MsgRequestFailure { // Placeholder
+    // No fields for this message as per RFC 4254, Section 4
+    // pub data: Vec<u8>,
+}
+impl SSHMagic for MsgRequestFailure {
+    const MAGIC: u8 = Magic::RequestFailure as u8;
+}
+
+#[derive(Debug, PartialEq, ReadSSH, WriteSSH)]
+pub struct MsgChannelOpen { // Placeholder
+    pub channel_type: String, // "session", "x11", "forwarded-tcpip", "direct-tcpip"
+    pub sender_channel: u32,
+    pub initial_window_size: u32,
+    pub maximum_packet_size: u32,
+    // Type-specific data omitted for now
+}
+impl SSHMagic for MsgChannelOpen {
+    const MAGIC: u8 = Magic::ChannelOpen as u8;
+}
+
+#[derive(Debug, PartialEq, ReadSSH, WriteSSH)]
+pub struct MsgChannelOpenConfirmation { // Placeholder
+    pub recipient_channel: u32,
+    pub sender_channel: u32,
+    pub initial_window_size: u32,
+    pub maximum_packet_size: u32,
+    // Type-specific data omitted for now
+}
+impl SSHMagic for MsgChannelOpenConfirmation {
+    const MAGIC: u8 = Magic::ChannelOpenConfirmation as u8;
+}
+
+#[derive(Debug, PartialEq, ReadSSH, WriteSSH)]
+pub struct MsgChannelOpenFailure { // Placeholder
+    pub recipient_channel: u32,
+    pub reason_code: ChannelOpenFailureReasonCode,
+    pub description: String,
+    pub language_tag: String,
+}
+impl SSHMagic for MsgChannelOpenFailure {
+    const MAGIC: u8 = Magic::ChannelOpenFailure as u8;
+}
+
+#[derive(Debug, PartialEq, ReadSSH, WriteSSH)]
+pub struct MsgChannelWindowAdjust { // Placeholder
+    pub recipient_channel: u32,
+    pub bytes_to_add: u32,
+}
+impl SSHMagic for MsgChannelWindowAdjust {
+    const MAGIC: u8 = Magic::ChannelWindowAdjust as u8;
+}
+
+#[derive(Debug, PartialEq, ReadSSH, WriteSSH)]
+pub struct MsgChannelData { // Placeholder
+    pub recipient_channel: u32,
+    pub data: String, // Changed from Vec<u8>
+}
+impl SSHMagic for MsgChannelData {
+    const MAGIC: u8 = Magic::ChannelData as u8;
+}
+
+#[derive(Debug, PartialEq, ReadSSH, WriteSSH)]
+pub struct MsgChannelExtendedData { // Placeholder
+    pub recipient_channel: u32,
+    pub data_type_code: u32, // e.g., SSH_EXTENDED_DATA_STDERR (1)
+    pub data: String, // Changed from Vec<u8>
+}
+impl SSHMagic for MsgChannelExtendedData {
+    const MAGIC: u8 = Magic::ChannelExtendedData as u8;
+}
+
+#[derive(Debug, PartialEq, ReadSSH, WriteSSH)]
+pub struct MsgChannelEof { // Placeholder
+    pub recipient_channel: u32,
+}
+impl SSHMagic for MsgChannelEof {
+    const MAGIC: u8 = Magic::ChannelEof as u8;
+}
+
+#[derive(Debug, PartialEq, ReadSSH, WriteSSH)]
+pub struct MsgChannelClose { // Placeholder
+    pub recipient_channel: u32,
+}
+impl SSHMagic for MsgChannelClose {
+    const MAGIC: u8 = Magic::ChannelClose as u8;
+}
+
+#[derive(Debug, PartialEq, ReadSSH, WriteSSH)]
+pub struct MsgChannelRequest { // Placeholder
+    pub recipient_channel: u32,
+    pub request_type: String, // e.g., "pty-req", "shell", "exit-status"
+    pub want_reply: bool,
+    // Type-specific data omitted for now
+}
+impl SSHMagic for MsgChannelRequest {
+    const MAGIC: u8 = Magic::ChannelRequest as u8;
+}
+
+#[derive(Debug, PartialEq, ReadSSH, WriteSSH)]
+pub struct MsgChannelSuccess { // Placeholder
+    pub recipient_channel: u32,
+}
+impl SSHMagic for MsgChannelSuccess {
+    const MAGIC: u8 = Magic::ChannelSuccess as u8;
+}
+
+#[derive(Debug, PartialEq, ReadSSH, WriteSSH)]
+pub struct MsgChannelFailure { // Placeholder
+    pub recipient_channel: u32,
+}
+impl SSHMagic for MsgChannelFailure {
+    const MAGIC: u8 = Magic::ChannelFailure as u8;
+}
+
+
+#[derive(Debug, PartialEq)]
 #[allow(dead_code)]
 pub enum SSHMsg {
     Disconnect(MsgDisconnect),
@@ -368,4 +572,22 @@ pub enum SSHMsg {
     NewKeys(MsgNewKeys),
     KexECDHInit(MsgKexECDHInit),
     KexECDHReply(MsgKexECDHReply),
+    UserauthRequest(MsgUserauthRequest),
+    UserauthFailure(MsgUserauthFailure),
+    UserauthSuccess(MsgUserauthSuccess),
+    UserauthBanner(MsgUserauthBanner),
+    GlobalRequest(MsgGlobalRequest),
+    RequestSuccess(MsgRequestSuccess),
+    RequestFailure(MsgRequestFailure),
+    ChannelOpen(MsgChannelOpen),
+    ChannelOpenConfirmation(MsgChannelOpenConfirmation),
+    ChannelOpenFailure(MsgChannelOpenFailure),
+    ChannelWindowAdjust(MsgChannelWindowAdjust),
+    ChannelData(MsgChannelData),
+    ChannelExtendedData(MsgChannelExtendedData),
+    ChannelEof(MsgChannelEof),
+    ChannelClose(MsgChannelClose),
+    ChannelRequest(MsgChannelRequest),
+    ChannelSuccess(MsgChannelSuccess),
+    ChannelFailure(MsgChannelFailure),
 }

--- a/rustyssh/src/tests.rs
+++ b/rustyssh/src/tests.rs
@@ -1,0 +1,530 @@
+// Allow dead code for now, as tests will be added incrementally
+#![allow(dead_code)]
+
+use super::api::*;
+use super::msg::*;
+use std::io::Cursor;
+use pretty_hex::*; // For printing byte arrays during debugging if needed
+
+// Generic helper function for testing message serialization and deserialization
+fn test_message_serialization_deserialization<T>(
+    msg: T,
+) -> Result<SSHMsg, std::io::Error>
+where
+    T: WriteSSH + ReadSSH + PartialEq + std::fmt::Debug + SSHMagic,
+{
+    let mut bytes = Vec::new();
+    // msg.write_ssh(&mut bytes)?; // This would write the MAGIC byte from T, then fields
+                               // However, read_next_message expects only the fields after the initial magic byte.
+                               // The write_ssh for message structs (derived via WriteSSH macro) prepends the MAGIC byte.
+                               // So, the full output of msg.write_ssh() is what read_next_message should be able to parse
+                               // if we strip the first magic byte before giving it to specific MsgType::read_ssh.
+                               // BUT read_next_message itself reads the first magic byte. So this is correct.
+
+    msg.write_ssh(&mut bytes)?;
+
+    assert!(!bytes.is_empty(), "Serialized bytes should not be empty");
+    assert_eq!(
+        bytes[0],
+        T::MAGIC,
+        "First byte of serialized data should match T::MAGIC"
+    );
+
+    let mut cursor = Cursor::new(bytes);
+    // read_next_message reads the magic byte from the cursor and then calls the appropriate
+    // MsgType::read_ssh for the rest of the data.
+    super::msg::read_next_message(&mut cursor)
+}
+
+#[test]
+fn test_msg_disconnect_serialization_deserialization() {
+    // Ensure DisconnectCode derives Clone, or create `original_msg` inside the match for comparison.
+    // For now, assuming we'll add Clone to DisconnectCode if needed.
+    let original_msg = MsgDisconnect {
+        code: DisconnectCode::ProtocolError,
+        description: "Test disconnect message".to_string(),
+        language: "en-US".to_string(),
+    };
+
+    let result = test_message_serialization_deserialization(original_msg.clone());
+
+    match result {
+        Ok(SSHMsg::Disconnect(deserialized_msg)) => {
+            assert_eq!(original_msg, deserialized_msg);
+        }
+        Ok(other_msg) => {
+            panic!("Expected SSHMsg::Disconnect, but got {:?}", other_msg);
+        }
+        Err(e) => {
+            panic!("Serialization/deserialization failed: {:?}", e);
+        }
+    }
+}
+
+// Helper for testing u32-backed enums
+fn test_enum_u32_serialization_deserialization<E>(
+    enum_val: E,
+    expected_u32: u32,
+) where
+    E: WriteSSH + ReadSSH + PartialEq + std::fmt::Debug + Copy,
+{
+    let mut bytes = Vec::new();
+    enum_val.write_ssh(&mut bytes).unwrap();
+    assert_eq!(bytes, expected_u32.to_be_bytes());
+
+    let mut cursor = Cursor::new(bytes);
+    let deserialized_val = E::read_ssh(&mut cursor).unwrap();
+    assert_eq!(enum_val, deserialized_val);
+}
+
+#[test]
+fn test_channel_open_failure_reason_code_serialization() {
+    test_enum_u32_serialization_deserialization(
+        ChannelOpenFailureReasonCode::AdministrativelyProhibited,
+        1u32,
+    );
+    test_enum_u32_serialization_deserialization(
+        ChannelOpenFailureReasonCode::ConnectFailed,
+        2u32,
+    );
+    test_enum_u32_serialization_deserialization(
+        ChannelOpenFailureReasonCode::UnknownChannelType,
+        3u32,
+    );
+    test_enum_u32_serialization_deserialization(
+        ChannelOpenFailureReasonCode::ResourceShortage,
+        4u32,
+    );
+}
+
+#[test]
+fn test_pseudo_terminal_modes_serialization() {
+    test_enum_u32_serialization_deserialization(PseudoTerminalModes::TTY_OP_END, 0u32);
+    test_enum_u32_serialization_deserialization(PseudoTerminalModes::VINTR, 1u32);
+    test_enum_u32_serialization_deserialization(PseudoTerminalModes::VERASE, 3u32);
+    // Add a few more representative values
+    test_enum_u32_serialization_deserialization(PseudoTerminalModes::ISIG, 50u32);
+    test_enum_u32_serialization_deserialization(PseudoTerminalModes::TTY_OP_OSPEED, 129u32);
+}
+
+// Helper for testing string-based enums
+fn test_string_enum_serialization<E>(
+    enum_val: E,
+    expected_str: &str,
+) where
+    E: WriteSSH + ReadSSH + PartialEq + std::fmt::Debug + Clone, // Clone because we might consume enum_val for expected_bytes
+{
+    // Test serialization
+    let mut bytes = Vec::new();
+    enum_val.write_ssh(&mut bytes).unwrap();
+
+    let mut expected_bytes = Vec::new();
+    (expected_str.len() as u32).write_ssh(&mut expected_bytes).unwrap();
+    expected_bytes.extend_from_slice(expected_str.as_bytes());
+    assert_eq!(bytes, expected_bytes, "Mismatch for enum variant representing '{}'", expected_str);
+
+    // Test deserialization
+    let mut cursor = Cursor::new(bytes);
+    let deserialized_val = E::read_ssh(&mut cursor).unwrap();
+    assert_eq!(enum_val, deserialized_val, "Mismatch after deserializing for enum variant representing '{}'", expected_str);
+}
+
+fn test_string_enum_unknown_variant<E>(
+    unknown_string_val: String,
+    constructor: fn(String) -> E,
+) where
+    E: WriteSSH + ReadSSH + PartialEq + std::fmt::Debug + Clone,
+{
+    let original_enum_unknown = constructor(unknown_string_val.clone());
+    
+    // Test serialization of Unknown(string)
+    let mut bytes_unknown = Vec::new();
+    original_enum_unknown.write_ssh(&mut bytes_unknown).unwrap();
+
+    let mut expected_bytes_unknown = Vec::new();
+    (unknown_string_val.len() as u32).write_ssh(&mut expected_bytes_unknown).unwrap();
+    expected_bytes_unknown.extend_from_slice(unknown_string_val.as_bytes());
+    assert_eq!(bytes_unknown, expected_bytes_unknown, "Mismatch for Unknown variant with string '{}'", unknown_string_val);
+
+    // Test deserialization of Unknown(string)
+    let mut cursor_unknown = Cursor::new(bytes_unknown);
+    let deserialized_unknown = E::read_ssh(&mut cursor_unknown).unwrap();
+    assert_eq!(original_enum_unknown, deserialized_unknown, "Mismatch after deserializing Unknown variant with string '{}'", unknown_string_val);
+}
+
+#[test]
+fn test_key_exchange_method_serialization() {
+    test_string_enum_serialization(KeyExchangeMethod::ecdh__sha2__nistp256, "ecdh-sha2-nistp256");
+    test_string_enum_unknown_variant("my-kex@example.com".to_string(), KeyExchangeMethod::Unknown);
+}
+
+#[test]
+fn test_encryption_algorithm_serialization() {
+    test_string_enum_serialization(EncryptionAlgorithm::aes128__ctr, "aes128-ctr");
+    test_string_enum_serialization(EncryptionAlgorithm::none, "none");
+    test_string_enum_unknown_variant("custom-cipher".to_string(), EncryptionAlgorithm::Unknown);
+}
+
+#[test]
+fn test_mac_algorithm_serialization() {
+    test_string_enum_serialization(MACAlgorithm::hmac__sha1, "hmac-sha1");
+    test_string_enum_serialization(MACAlgorithm::hmac__sha2__256, "hmac-sha2-256");
+    test_string_enum_serialization(MACAlgorithm::none, "none");
+    test_string_enum_unknown_variant("custom-mac".to_string(), MACAlgorithm::Unknown);
+}
+
+#[test]
+fn test_public_key_algorithm_serialization() {
+    test_string_enum_serialization(PublicKeyAlgorithm::ssh__rsa, "ssh-rsa");
+    test_string_enum_serialization(PublicKeyAlgorithm::ssh__ed25519, "ssh-ed25519");
+    test_string_enum_unknown_variant("custom-pubkey".to_string(), PublicKeyAlgorithm::Unknown);
+}
+
+#[test]
+fn test_compression_algorithm_serialization() {
+    test_string_enum_serialization(CompressionAlgorithm::zlib, "zlib");
+    test_string_enum_serialization(CompressionAlgorithm::none, "none");
+    test_string_enum_unknown_variant("custom-comp".to_string(), CompressionAlgorithm::Unknown);
+}
+
+#[test]
+fn test_service_serialization() {
+    test_string_enum_serialization(Service::ssh__userauth, "ssh-userauth");
+    test_string_enum_serialization(Service::ssh__connection, "ssh-connection");
+    // Assuming Service does not have an Unknown variant based on its definition
+}
+
+#[test]
+fn test_authentication_method_serialization() {
+    test_string_enum_serialization(AuthenticationMethod::publickey, "publickey");
+    test_string_enum_serialization(AuthenticationMethod::password, "password");
+    test_string_enum_serialization(AuthenticationMethod::hostBased, "hostBased"); // Note: macro should handle case
+    test_string_enum_serialization(AuthenticationMethod::none, "none");
+    // Assuming AuthenticationMethod does not have an Unknown variant
+}
+
+#[test]
+fn test_connection_protocol_channel_type_serialization() {
+    test_string_enum_serialization(ConnectionProtocolChannelType::session, "session");
+    test_string_enum_serialization(ConnectionProtocolChannelType::x11, "x11");
+    test_string_enum_serialization(ConnectionProtocolChannelType::forwarded__tcpip, "forwarded-tcpip");
+    test_string_enum_serialization(ConnectionProtocolChannelType::direct__tcpip, "direct-tcpip");
+    // Assuming ConnectionProtocolChannelType does not have an Unknown variant
+}
+
+#[test]
+fn test_connection_protocol_request_type_serialization() {
+    test_string_enum_serialization(ConnectionProtocolRequestType::tcpip__forward, "tcpip-forward");
+    test_string_enum_serialization(ConnectionProtocolRequestType::cancel__tcpip__forward, "cancel-tcpip-forward");
+    // Assuming ConnectionProtocolRequestType does not have an Unknown variant
+}
+
+#[test]
+fn test_connection_protocol_channel_request_name_serialization() {
+    test_string_enum_serialization(ConnectionProtocolChannelRequestName::pty__req, "pty-req");
+    test_string_enum_serialization(ConnectionProtocolChannelRequestName::shell, "shell");
+    test_string_enum_serialization(ConnectionProtocolChannelRequestName::exit__signal, "exit-signal");
+    // Assuming ConnectionProtocolChannelRequestName does not have an Unknown variant
+}
+
+#[test]
+fn test_signal_name_serialization() {
+    // The erroneous call to test_enum_u32_serialization_deserialization has been removed.
+    // Reframing SignalName test as string based.
+    // The derive macro for Read/WriteSSH for string enums expects string-based values.
+    // SignalName is currently derived as simple names, not u32.
+    // The previous change to add Copy to SignalName was an error, it should be Clone only if it's string based
+    // Let's assume it's meant to be string based like others without explicit repr(u32)
+    test_string_enum_serialization(SignalName::ABRT, "ABRT");
+    test_string_enum_serialization(SignalName::KILL, "KILL");
+    // Assuming SignalName does not have an Unknown variant
+}
+
+// --- Edge Case and Error Handling Tests ---
+
+#[test]
+fn test_read_next_message_invalid_magic() {
+    let invalid_magic_bytes = [255u8, 0, 0, 0]; // 255 is not a valid SSH message type
+    let mut cursor = Cursor::new(&invalid_magic_bytes[..]);
+    let result = super::msg::read_next_message(&mut cursor);
+    assert!(result.is_err(), "Expected an error for invalid magic number");
+    if let Err(e) = result {
+        assert_eq!(e.kind(), std::io::ErrorKind::InvalidData, "Error kind should be InvalidData for unknown magic number");
+    }
+}
+
+#[test]
+fn test_read_next_message_insufficient_data() {
+    // MsgUnimplemented requires a u32, so 4 bytes after magic. We provide only 2.
+    let insufficient_data_bytes = [MsgUnimplemented::MAGIC, 1, 2]; 
+    let mut cursor = Cursor::new(&insufficient_data_bytes[..]);
+    let result = super::msg::read_next_message(&mut cursor);
+    assert!(result.is_err(), "Expected an error for insufficient data after magic number");
+    if let Err(e) = result {
+        // This will likely be UnexpectedEof because read_u32 will try to read 4 bytes.
+        assert_eq!(e.kind(), std::io::ErrorKind::UnexpectedEof, "Error kind should be UnexpectedEof for insufficient data for MsgUnimplemented payload");
+    }
+}
+
+#[test]
+fn test_string_read_ssh_malformed_data() {
+    // Scenario 1: Length declares more bytes than available
+    let bytes_len_too_long = [0u8, 0, 0, 10, b'h', b'e', b'l', b'l', b'o']; // Length 10, actual "hello" (5 bytes)
+    let mut cursor1 = Cursor::new(&bytes_len_too_long[..]);
+    let result1 = String::read_ssh(&mut cursor1);
+    assert!(result1.is_err(), "Expected error for string length > available bytes");
+    if let Err(e) = result1 {
+        assert_eq!(e.kind(), std::io::ErrorKind::UnexpectedEof, "Error kind should be UnexpectedEof for string length > available");
+    }
+
+    // Scenario 2: Invalid UTF-8 sequence
+    let bytes_invalid_utf8 = [0u8, 0, 0, 4, 0xC3, 0x28, 0xA0, 0xA1]; // Invalid UTF-8 sequence \xC3\x28
+    let mut cursor2 = Cursor::new(&bytes_invalid_utf8[..]);
+    let result2 = String::read_ssh(&mut cursor2);
+    assert!(result2.is_err(), "Expected error for invalid UTF-8 sequence");
+    if let Err(e) = result2 {
+        assert_eq!(e.kind(), std::io::ErrorKind::InvalidData, "Error kind should be InvalidData for invalid UTF-8");
+    }
+}
+
+#[test]
+fn test_name_list_read_ssh_malformed_data() {
+    // Scenario 1: Name-list length declares more bytes than available
+    let bytes_len_too_long = [0u8, 0, 0, 20, b'a', b',', b'b']; // Length 20, actual "a,b" (3 bytes)
+    let mut cursor1 = Cursor::new(&bytes_len_too_long[..]);
+    let result1 = Vec::<String>::read_ssh(&mut cursor1);
+    assert!(result1.is_err(), "Expected error for name-list length > available bytes");
+    if let Err(e) = result1 {
+        assert_eq!(e.kind(), std::io::ErrorKind::UnexpectedEof, "Error kind should be UnexpectedEof for name-list length > available");
+    }
+
+    // Scenario 2: Invalid UTF-8 sequence in name-list
+    let bytes_invalid_utf8 = [0u8, 0, 0, 4, 0xC3, 0x28, 0xA0, 0xA1]; // Invalid UTF-8 sequence \xC3\x28
+    let mut cursor2 = Cursor::new(&bytes_invalid_utf8[..]);
+    let result2 = Vec::<String>::read_ssh(&mut cursor2);
+    assert!(result2.is_err(), "Expected error for invalid UTF-8 sequence in name-list");
+    if let Err(e) = result2 {
+        assert_eq!(e.kind(), std::io::ErrorKind::InvalidData, "Error kind should be InvalidData for invalid UTF-8 in name-list");
+    }
+}
+
+#[test]
+fn test_u32_enum_invalid_discriminant() {
+    // ChannelOpenFailureReasonCode max valid discriminant is 4. Use 5.
+    let invalid_discriminant_bytes = 5u32.to_be_bytes();
+    let mut cursor = Cursor::new(&invalid_discriminant_bytes[..]);
+    let result = ChannelOpenFailureReasonCode::read_ssh(&mut cursor);
+    assert!(result.is_err(), "Expected error for invalid u32 enum discriminant");
+    if let Err(e) = result {
+        assert_eq!(e.kind(), std::io::ErrorKind::InvalidData, "Error kind should be InvalidData for invalid u32 enum discriminant");
+    }
+}
+
+#[test]
+fn test_string_enum_invalid_variant() {
+    // Service enum does not have an "Unknown" variant.
+    let invalid_variant_str = "this-is-not-a-valid-service-name";
+    let mut bytes = Vec::new();
+    // Manually serialize this string as if it were a name-list/string payload
+    (invalid_variant_str.len() as u32).write_ssh(&mut bytes).unwrap();
+    bytes.extend_from_slice(invalid_variant_str.as_bytes());
+    
+    let mut cursor = Cursor::new(&bytes[..]);
+    let result = Service::read_ssh(&mut cursor);
+    assert!(result.is_err(), "Expected error for invalid string enum variant");
+    if let Err(e) = result {
+        assert_eq!(e.kind(), std::io::ErrorKind::InvalidData, "Error kind should be InvalidData for invalid string enum variant");
+    }
+}
+
+#[test]
+fn test_msg_kex_init_serialization_deserialization() {
+    // Scenario 1: Empty Name-Lists
+    let original_msg_empty = MsgKexInit {
+        cookie: [1u8; 16],
+        kex_algorithms: Vec::new(),
+        server_host_key_algorithms: Vec::new(),
+        encryption_algorithms_client_to_server: Vec::new(),
+        encryption_algorithms_server_to_client: Vec::new(),
+        mac_algorithms_client_to_server: Vec::new(),
+        mac_algorithms_server_to_client: Vec::new(),
+        compression_algorithms_client_to_server: Vec::new(),
+        compression_algorithms_server_to_client: Vec::new(),
+        languages_client_to_server: Vec::new(),
+        languages_server_to_client: Vec::new(),
+        kex_first_packet_follows: false,
+        reserved: 0,
+    };
+
+    let result_empty = test_message_serialization_deserialization(original_msg_empty.clone());
+    match result_empty {
+        Ok(SSHMsg::KexInit(deserialized_msg)) => {
+            assert_eq!(original_msg_empty, deserialized_msg);
+        }
+        Ok(other_msg) => panic!("Scenario 1 (empty lists): Expected SSHMsg::KexInit, but got {:?}", other_msg),
+        Err(e) => panic!("Scenario 1 (empty lists) failed: {:?}", e),
+    }
+
+    // Scenario 2: Single Item Name-Lists
+    let original_msg_single = MsgKexInit {
+        cookie: [2u8; 16],
+        kex_algorithms: vec!["curve25519-sha256".to_string()],
+        server_host_key_algorithms: vec!["ssh-ed25519".to_string()],
+        encryption_algorithms_client_to_server: vec!["aes128-ctr".to_string()],
+        encryption_algorithms_server_to_client: vec!["aes128-ctr".to_string()],
+        mac_algorithms_client_to_server: vec!["hmac-sha2-256".to_string()],
+        mac_algorithms_server_to_client: vec!["hmac-sha2-256".to_string()],
+        compression_algorithms_client_to_server: vec!["none".to_string()],
+        compression_algorithms_server_to_client: vec!["none".to_string()],
+        languages_client_to_server: vec!["en-US".to_string()],
+        languages_server_to_client: vec!["en-US".to_string()],
+        kex_first_packet_follows: true,
+        reserved: 0,
+    };
+
+    let result_single = test_message_serialization_deserialization(original_msg_single.clone());
+    match result_single {
+        Ok(SSHMsg::KexInit(deserialized_msg)) => {
+            assert_eq!(original_msg_single, deserialized_msg);
+        }
+        Ok(other_msg) => panic!("Scenario 2 (single item): Expected SSHMsg::KexInit, but got {:?}", other_msg),
+        Err(e) => panic!("Scenario 2 (single item) failed: {:?}", e),
+    }
+
+    // Scenario 3: Multiple Item Name-Lists
+    let original_msg_multiple = MsgKexInit {
+        cookie: [3u8; 16],
+        kex_algorithms: vec!["curve25519-sha256".to_string(), "diffie-hellman-group-exchange-sha256".to_string()],
+        server_host_key_algorithms: vec!["ssh-ed25519".to_string(), "rsa-sha2-512".to_string()],
+        encryption_algorithms_client_to_server: vec!["aes128-ctr".to_string(), "aes256-ctr".to_string()],
+        encryption_algorithms_server_to_client: vec!["aes128-ctr".to_string(), "aes256-ctr".to_string()],
+        mac_algorithms_client_to_server: vec!["hmac-sha2-256".to_string(), "hmac-sha1".to_string()],
+        mac_algorithms_server_to_client: vec!["hmac-sha2-256".to_string(), "hmac-sha1".to_string()],
+        compression_algorithms_client_to_server: vec!["none".to_string(), "zlib@openssh.com".to_string()],
+        compression_algorithms_server_to_client: vec!["none".to_string(), "zlib@openssh.com".to_string()],
+        languages_client_to_server: vec!["en-US".to_string(), "en-GB".to_string()],
+        languages_server_to_client: vec!["en-US".to_string(), "en-GB".to_string()],
+        kex_first_packet_follows: false,
+        reserved: 0,
+    };
+
+    let result_multiple = test_message_serialization_deserialization(original_msg_multiple.clone());
+    match result_multiple {
+        Ok(SSHMsg::KexInit(deserialized_msg)) => {
+            assert_eq!(original_msg_multiple, deserialized_msg);
+        }
+        Ok(other_msg) => panic!("Scenario 3 (multiple items): Expected SSHMsg::KexInit, but got {:?}", other_msg),
+        Err(e) => panic!("Scenario 3 (multiple items) failed: {:?}", e),
+    }
+
+    // Scenario 4: Mixed Empty and Non-Empty Name-Lists
+    let original_msg_mixed = MsgKexInit {
+        cookie: [4u8; 16],
+        kex_algorithms: vec!["curve25519-sha256".to_string()],
+        server_host_key_algorithms: Vec::new(), // Empty
+        encryption_algorithms_client_to_server: vec!["aes128-ctr".to_string(), "aes256-ctr".to_string()],
+        encryption_algorithms_server_to_client: Vec::new(), // Empty
+        mac_algorithms_client_to_server: vec!["hmac-sha2-256".to_string()],
+        mac_algorithms_server_to_client: Vec::new(), // Empty
+        compression_algorithms_client_to_server: vec!["none".to_string(), "zlib@openssh.com".to_string()],
+        compression_algorithms_server_to_client: Vec::new(), // Empty
+        languages_client_to_server: vec!["en-US".to_string()],
+        languages_server_to_client: Vec::new(), // Empty
+        kex_first_packet_follows: true,
+        reserved: 0,
+    };
+
+    let result_mixed = test_message_serialization_deserialization(original_msg_mixed.clone());
+    match result_mixed {
+        Ok(SSHMsg::KexInit(deserialized_msg)) => {
+            assert_eq!(original_msg_mixed, deserialized_msg);
+        }
+        Ok(other_msg) => panic!("Scenario 4 (mixed): Expected SSHMsg::KexInit, but got {:?}", other_msg),
+        Err(e) => panic!("Scenario 4 (mixed) failed: {:?}", e),
+    }
+}
+
+#[test]
+fn test_msg_ignore_serialization_deserialization() {
+    let original_msg = MsgIgnore {
+        data: "Test ignore message".to_string(),
+    };
+
+    let result = test_message_serialization_deserialization(original_msg.clone());
+
+    match result {
+        Ok(SSHMsg::Ignore(deserialized_msg)) => {
+            assert_eq!(original_msg, deserialized_msg);
+        }
+        Ok(other_msg) => {
+            panic!("Expected SSHMsg::Ignore, but got {:?}", other_msg);
+        }
+        Err(e) => {
+            panic!("Serialization/deserialization failed: {:?}", e);
+        }
+    }
+}
+
+#[test]
+fn test_msg_unimplemented_serialization_deserialization() {
+    let original_msg = MsgUnimplemented {
+        packet_sequence_number: 12345,
+    };
+
+    let result = test_message_serialization_deserialization(original_msg.clone());
+
+    match result {
+        Ok(SSHMsg::Unimplemented(deserialized_msg)) => {
+            assert_eq!(original_msg, deserialized_msg);
+        }
+        Ok(other_msg) => {
+            panic!("Expected SSHMsg::Unimplemented, but got {:?}", other_msg);
+        }
+        Err(e) => {
+            panic!("Serialization/deserialization failed: {:?}", e);
+        }
+    }
+}
+
+#[test]
+fn test_msg_debug_serialization_deserialization() {
+    let original_msg = MsgDebug {
+        always_display: true,
+        message: "Test debug message".to_string(),
+        language: "en-GB".to_string(),
+    };
+
+    let result = test_message_serialization_deserialization(original_msg.clone());
+
+    match result {
+        Ok(SSHMsg::Debug(deserialized_msg)) => {
+            assert_eq!(original_msg, deserialized_msg);
+        }
+        Ok(other_msg) => {
+            panic!("Expected SSHMsg::Debug, but got {:?}", other_msg);
+        }
+        Err(e) => {
+            panic!("Serialization/deserialization failed: {:?}", e);
+        }
+    }
+}
+
+#[test]
+fn test_msg_newkeys_serialization_deserialization() {
+    let original_msg = MsgNewKeys {}; // Unit struct
+
+    // Explicitly clone, even for Copy types, for consistency and to satisfy the borrow checker after move.
+    let result = test_message_serialization_deserialization(original_msg.clone()); 
+
+    match result {
+        Ok(SSHMsg::NewKeys(deserialized_msg)) => {
+            assert_eq!(original_msg, deserialized_msg);
+        }
+        Ok(other_msg) => {
+            panic!("Expected SSHMsg::NewKeys, but got {:?}", other_msg);
+        }
+        Err(e) => {
+            panic!("Serialization/deserialization failed: {:?}", e);
+        }
+    }
+}

--- a/rustyssh_derive/src/lib.rs
+++ b/rustyssh_derive/src/lib.rs
@@ -88,9 +88,10 @@ pub fn derive_read_ssh(input: TokenStream) -> TokenStream {
             // Code for enums without discriminants, using string names
             let variant_matches = data.variants.iter().map(|v| {
                 let variant = &v.ident;
-                let variant_str = variant.to_string();
+                // Apply the same transformation as in WriteSSH for consistent matching
+                let variant_str = variant.to_string().replace("__", "-"); 
 
-                if !variant_str.contains("Unknown") {
+                if !variant.to_string().contains("Unknown") { // Check original ident string for "Unknown"
                     quote! {
                         name if name == #variant_str => Ok(#struct_name::#variant),
                     }
@@ -191,24 +192,102 @@ pub fn derive_write_ssh(input: TokenStream) -> TokenStream {
         }
         Data::Enum(data) if !has_discriminants(&data.variants) => {
             let variant_matches = data.variants.iter().map(|v| {
-                let variant = &v.ident;
-                let variant_str = variant.to_string().replace("__", "-");
+                let variant_ident = &v.ident;
+                let variant_name_str = variant_ident.to_string();
 
-                if !variant_str.contains("Unknown") {
-                    quote! {
-                        #struct_name::#variant => #variant_str.write_ssh(writer),
+                if variant_name_str == "Unknown" {
+                    match &v.fields {
+                        Fields::Unnamed(fields_unnamed) if fields_unnamed.unnamed.len() == 1 => {
+                            // Assumes the single field is the string to be written
+                            // The `ref val` part will bind the inner value of the enum variant
+                            quote! {
+                                #struct_name::#variant_ident(ref val) => val.write_ssh(writer),
+                            }
+                        }
+                        _ => {
+                            // Fallback for Unknown variants that are not Unknown(String)
+                            // This could either serialize the "Unknown" name or error.
+                            // For now, let's make it error out, or serialize its name if it's a unit variant.
+                            // If it's a unit variant Unknown, serialize its name.
+                            if matches!(v.fields, Fields::Unit) {
+                                let unknown_variant_name_literal = variant_name_str.replace("__", "-");
+                                quote! {
+                                    #struct_name::#variant_ident => #unknown_variant_name_literal.write_ssh(writer),
+                                }
+                            } else {
+                                // For Unknown variants that are not simple Unit or Unnamed(String)
+                                quote! {
+                                    #struct_name::#variant_ident(..) => return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, "Cannot serialize complex Unknown variant")),
+                                }
+                            }
+                        }
                     }
                 } else {
-                    quote! {}
+                    let variant_name_literal = variant_name_str.replace("__", "-");
+                    quote! {
+                        #struct_name::#variant_ident => #variant_name_literal.to_string().write_ssh(writer),
+                    }
                 }
             });
+
+            // let mut has_unknown_catch_all = false;
+            // for v in data.variants.iter() {
+            //     if v.ident.to_string() == "Unknown" {
+            //         if let Fields::Unnamed(fields_unnamed) = &v.fields {
+            //             if fields_unnamed.unnamed.len() == 1 {
+            //                 has_unknown_catch_all = true;
+            //                 break;
+            //             }
+            //         }
+            //     }
+            // }
+
+            // If there isn't an Unknown(String) variant, we add a default error case.
+            // Otherwise, the Unknown(String) variant acts as the catch-all for strings.
+            // let default_case = if !has_unknown_catch_all {
+            //     quote! { _ => return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, "Unmatched enum variant for WriteSSH")), }
+            // } else {
+            //     // If an Unknown(String) variant exists, other non-matching variants should still error.
+            //     // The generated match arms should cover all defined variants.
+            //     // A specific unit `Unknown` would be handled by its own arm.
+            //     // This is tricky because `Unknown(String)` is for deserializing arbitrary strings,
+            //     // but for serializing, we only care about the specific variants defined.
+            //     // The match should be exhaustive for defined variants.
+            //     // The provided example has `MyEnum::Unknown(s) => s.write_ssh(writer),` and no other catch-all.
+            //     // This implies the match should be exhaustive over *known* variants + the special Unknown(String).
+            //     // So, if all other variants are explicitly matched, what would `_` catch?
+            //     // It would catch nothing if all variants are handled.
+            //     // Let's ensure all variants are explicitly handled.
+            //     // The `variant_matches` should cover all cases.
+            //     // If there's an `Unknown(String)` it's handled. If there's a unit `Unknown`, it's handled.
+            //     // Other variants are handled.
+            //     // So, a generic `_` might only be needed if some variants were filtered out, which they aren't.
+            //     // However, if an enum has `Unknown(Foo)` and `Unknown(Bar)`, the logic above only handles one.
+            //     // The current logic only handles one `Unknown(String)` like variant.
+            //     // The fallback error is good.
+            //      quote! { _ => return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, "Enum variant not serializable as string (and not Unknown(String))")), }
+            // };
 
             quote! {
                 impl WriteSSH for #struct_name {
                     fn write_ssh<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
                         match self {
                             #( #variant_matches )*
-                            _ => Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "Invalid enum variant name"))
+                            // The default case is now more nuanced.
+                            // If all variants are covered by variant_matches, this _ might not be needed
+                            // or could be a specific error for truly unexpected states.
+                            // For enums like KeyExchangeMethod where Unknown(String) is a valid state to serialize.
+                            // The logic above for variant_matches tries to create an arm for each variant.
+                            // If there's an Unknown(String) variant, its arm is `Enum::Unknown(ref val) => val.write_ssh(writer)`.
+                            // This means the `_` arm below would only be hit if `variant_matches` somehow doesn't cover all variants.
+                            // This should ideally be an exhaustive match.
+                            // The problem description implies Unknown(s) is one of the match arms, not a catch-all.
+                            // So the _ should only be for truly unexpected variants not defined in the enum.
+                            // But match self should be exhaustive.
+                            // Let's remove the catch-all _ if all variants are handled by `variant_matches`.
+                            // The default_case logic above is trying to decide if a catch-all is needed.
+                            // For now, let's keep a generic error for safety, as the logic for `variant_matches` might not be perfect.
+                            _ => Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "Unhandled enum variant in WriteSSH (should be exhaustive)"))
                         }
                     }
                 }


### PR DESCRIPTION
-   Added RFC 4250 for reference.
-   Enhancements to the `read_next_message` function to recognize and attempt parsing for all SSH message types.
-   Fixes to procedural macros in `rustyssh_derive` related to enum serialization and deserialization.
-   The implementation of a thorough test suite covering various message structs, name-list handling, enum types, edge cases, and error handling.
-   Bug fixes identified by these new tests, particularly concerning empty name-lists and enum handling.