### PR TITLE
Implement initial SSH handshake and KEXINIT exchange

### DIFF
--- a/rustyssh/Cargo.lock
+++ b/rustyssh/Cargo.lock
@@ -89,6 +89,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,9 +146,9 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "linux-raw-sys"
@@ -162,6 +173,7 @@ dependencies = [
  "num_enum",
  "openssl",
  "pretty-hex",
+ "rand",
  "rustyssh_derive",
  "serde",
  "serde_json",
@@ -246,6 +258,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "pretty-hex"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,20 +283,50 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.70"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -369,9 +420,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.39"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -435,6 +486,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "winapi"
@@ -606,4 +663,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40460c13b1e9b107cfc9ede71232f204c36250bbf6f9c78515e2e27ead3122a7"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]

--- a/rustyssh/Cargo.toml
+++ b/rustyssh/Cargo.toml
@@ -15,3 +15,4 @@ anyhow = "1.0"
 openssl = "0.10"
 pretty-hex = "0.4.0"
 rustyssh_derive = { path = "../rustyssh_derive" }
+rand = "0.8"

--- a/rustyssh/src/api.rs
+++ b/rustyssh/src/api.rs
@@ -95,6 +95,26 @@ impl WriteSSH for String {
     }
 }
 
+impl ReadSSH for Vec<u8> {
+    fn read_ssh<R: std::io::Read>(mut reader: R) -> Result<Self, std::io::Error>
+    where
+        Self: Sized,
+    {
+        let length = u32::read_ssh(&mut reader)? as usize;
+        let mut buffer = vec![0; length];
+        reader.read_exact(&mut buffer)?;
+        Ok(buffer)
+    }
+}
+
+impl WriteSSH for Vec<u8> {
+    fn write_ssh<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        let length = self.len() as u32;
+        length.write_ssh(writer)?;
+        writer.write_all(self)
+    }
+}
+
 impl WriteSSH for &'static str {
     fn write_ssh<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
         writer.write_all(self.as_bytes())?;

--- a/rustyssh/src/main.rs
+++ b/rustyssh/src/main.rs
@@ -1,4 +1,9 @@
-use std::io::Cursor;
+use std::io::{Cursor, Read, Write}; // Cursor re-added
+use std::net::TcpStream;
+use std::process;
+use std::time::Duration;
+
+use rand::RngCore; // Added for random cookie
 
 mod api;
 mod msg;
@@ -9,45 +14,448 @@ use crate::api::WriteSSH;
 use crate::msg::*;
 
 fn main() -> std::io::Result<()> {
-    // Create an instance of Disconnect
-    let obj = MsgKexInit {
-        cookie: [2u8; 16],
-        kex_algorithms: vec!["kex_algorithms".to_string()],
-        server_host_key_algorithms: vec!["server_host_key_algorithms".to_string()],
-        encryption_algorithms_client_to_server: vec![
-            "encryption_algorithms_client_to_server".to_string()
-        ],
-        encryption_algorithms_server_to_client: vec![
-            "encryption_algorithms_server_to_client".to_string()
-        ],
-        mac_algorithms_client_to_server: vec!["mac_algorithms_client_to_server".to_string()],
-        mac_algorithms_server_to_client: vec!["mac_algorithms_server_to_client".to_string()],
-        compression_algorithms_client_to_server: vec![
-            "compression_algorithms_client_to_server".to_string()
-        ],
-        compression_algorithms_server_to_client: vec![
-            "compression_algorithms_server_to_client".to_string()
-        ],
-        languages_client_to_server: vec!["languages_client_to_server".to_string()],
-        languages_server_to_client: vec!["languages_server_to_client".to_string()],
-        kex_first_packet_follows: false,
-        reserved: 32,
-    };
+    // Attempt to establish a TCP connection
+    match TcpStream::connect("localhost:22") {
+        Ok(mut stream) => {
+            println!("Successfully connected to localhost:22");
 
-    // Serialize into a byte array
-    let mut bytes = Vec::new();
-    obj.write_ssh(&mut bytes)?;
+            let protocol_version = "SSH-2.0-rustyssh_0.1.0\r\n";
+            println!("Sending protocol version: {}", protocol_version.trim_end()); // Log without CRLF for cleaner output
+            if let Err(e) = stream.write_all(protocol_version.as_bytes()) {
+                eprintln!("Failed to send protocol version: {}", e);
+                process::exit(1);
+            }
 
-    println!("Send: {:?}", obj);
-    println!("Byte: {:?}", bytes.hex_dump());
+            // Set a read timeout
+            if let Err(e) = stream.set_read_timeout(Some(Duration::new(5, 0))) {
+                eprintln!("Failed to set read timeout: {}", e);
+                process::exit(1);
+            }
 
-    // Deserialize from the byte array
-    let mut cursor = Cursor::new(bytes);
-    let deserialized_obj = read_next_message(&mut cursor)?;
+            // Read the server's protocol version string
+            let mut buffer = [0u8; 256];
+            match stream.read(&mut buffer) {
+                Ok(n) => {
+                    if n == 0 {
+                        eprintln!("Server closed connection prematurely while reading protocol string.");
+                        process::exit(1);
+                    }
+                    let server_response = String::from_utf8_lossy(&buffer[..n]);
+                    println!("Received from server: {}", server_response.trim());
 
-    // Check if deserialization is correct
-    println!("Rcvd: {:?}", deserialized_obj);
-    println!("Mgck: {:?}", MsgDisconnect::MAGIC);
+                    // Parse the server's protocol string
+                    // It should be something like "SSH-2.0-OpenSSH_8.9p1 Ubuntu-3ubuntu0.1\r\n"
+                    // We need to extract "SSH-2.0-OpenSSH_8.9p1 Ubuntu-3ubuntu0.1"
+                    let mut parts = server_response.trim_end().splitn(2, "\r\n");
+                    let server_protocol_string = parts.next().unwrap_or("").trim();
 
+
+                    if server_protocol_string.starts_with("SSH-2.0-") {
+                        println!("Parsed server protocol version: {}", server_protocol_string);
+                    } else {
+                        eprintln!(
+                            "Invalid server protocol string format. Expected 'SSH-2.0-...', got: {}",
+                            server_response.trim()
+                        );
+                        process::exit(1);
+                    }
+                }
+                Err(e) => {
+                    if e.kind() == std::io::ErrorKind::WouldBlock || e.kind() == std::io::ErrorKind::TimedOut {
+                        eprintln!("Timeout waiting for server protocol string.");
+                    } else {
+                        eprintln!("Failed to read server protocol string: {}", e);
+                    }
+                    process::exit(1);
+                }
+            }
+
+            // Construct MsgKexInit
+            let mut cookie = [0u8; 16];
+            rand::thread_rng().fill_bytes(&mut cookie);
+
+            let kex_init_payload = MsgKexInit {
+                cookie,
+                kex_algorithms: vec![
+                    "ecdh-sha2-nistp256".to_string(),
+                    "diffie-hellman-group-exchange-sha256".to_string(),
+                    "diffie-hellman-group14-sha256".to_string(),
+                ],
+                server_host_key_algorithms: vec![
+                    "ssh-ed25519".to_string(),
+                    "rsa-sha2-512".to_string(),
+                    "rsa-sha2-256".to_string(),
+                    "ssh-rsa".to_string(),
+                ],
+                encryption_algorithms_client_to_server: vec![
+                    "aes128-ctr".to_string(),
+                    "aes192-ctr".to_string(),
+                    "aes256-ctr".to_string(),
+                ],
+                encryption_algorithms_server_to_client: vec![
+                    "aes128-ctr".to_string(),
+                    "aes192-ctr".to_string(),
+                    "aes256-ctr".to_string(),
+                ],
+                mac_algorithms_client_to_server: vec![
+                    "hmac-sha2-256".to_string(),
+                    "hmac-sha1".to_string(),
+                ],
+                mac_algorithms_server_to_client: vec![
+                    "hmac-sha2-256".to_string(),
+                    "hmac-sha1".to_string(),
+                ],
+                compression_algorithms_client_to_server: vec!["none".to_string()],
+                compression_algorithms_server_to_client: vec!["none".to_string()],
+                languages_client_to_server: Vec::new(),
+                languages_server_to_client: Vec::new(),
+                kex_first_packet_follows: false,
+                reserved: 0, // As per RFC 4253, this should be 0
+            };
+
+            // Serialize into a byte array
+            let mut kex_init_bytes = Vec::new();
+            kex_init_payload.write_ssh(&mut kex_init_bytes)?;
+
+            println!("Sending KEXINIT: {:?}", kex_init_payload);
+            println!("KEXINIT Bytes: {:?}", kex_init_bytes.hex_dump());
+
+            // Send KEXINIT message
+            if let Err(e) = stream.write_all(&kex_init_bytes) {
+                eprintln!("Failed to send KEXINIT message: {}", e);
+                process::exit(1);
+            }
+
+            // For now, we are not processing the server's KEXINIT response
+            // The old deserialization test code is removed.
+
+            // Set read timeout again for server's KEXINIT
+            if let Err(e) = stream.set_read_timeout(Some(Duration::new(5, 0))) {
+                eprintln!("Failed to set read timeout for server KEXINIT: {}", e);
+                process::exit(1);
+            }
+
+            // Read the server's KEXINIT response
+            let mut kex_buffer = [0u8; 4096]; // Buffer for KEXINIT
+            match stream.read(&mut kex_buffer) {
+                Ok(bytes_read) => {
+                    if bytes_read == 0 {
+                        eprintln!("Server closed connection while waiting for KEXINIT.");
+                        process::exit(1);
+                    }
+                    println!(
+                        "Received KEXINIT raw bytes ({} bytes): {:?}",
+                        bytes_read,
+                        (&kex_buffer[..bytes_read]).hex_dump()
+                    );
+
+                    if bytes_read < 5 {
+                        eprintln!("Error: Received KEXINIT packet too short to contain length and padding info ({} bytes).", bytes_read);
+                        process::exit(1);
+                    }
+
+                    let packet_length = u32::from_be_bytes(kex_buffer[0..4].try_into().expect("Slice for packet_length is wrong size"));
+                    let padding_length = kex_buffer[4];
+
+                    // payload_in_packet_offset is the offset of the SSH message type code from the start of kex_buffer
+                    let payload_in_packet_offset = 5;
+
+                    // msg_payload_length is the length of the SSH message itself (e.g. KEXINIT data)
+                    // It does not include the packet_length field, padding_length field, or the random padding itself.
+                    if packet_length < (padding_length as u32 + 1) {
+                        eprintln!("Error: Invalid packet structure. packet_length ({}) is too small to accommodate padding_length ({}) + 1 byte for msg type.", packet_length, padding_length);
+                        process::exit(1);
+                    }
+                    let msg_payload_length = packet_length as usize - padding_length as usize - 1;
+
+                    // total_expected_bytes_for_this_packet is 4 (packet_length field) + its value (packet_length)
+                    let total_expected_bytes_for_this_packet = 4 + packet_length as usize;
+
+                    if bytes_read < total_expected_bytes_for_this_packet {
+                        eprintln!(
+                            "Error: Incomplete packet. Expected {} bytes for the full SSH packet based on its length field, but only received {} bytes.",
+                            total_expected_bytes_for_this_packet, bytes_read
+                        );
+                        // This could be a legitimate partial read, but for now, we'll treat it as an error.
+                        // A more robust client might buffer and retry reading.
+                        process::exit(1);
+                    }
+
+                    // The cursor should operate on the SSH message payload part of the buffer
+                    let ssh_message_payload_slice = &kex_buffer[payload_in_packet_offset .. payload_in_packet_offset + msg_payload_length];
+
+                    let mut cursor = Cursor::new(ssh_message_payload_slice);
+                    match read_next_message(&mut cursor) {
+                        Ok(SSHMsg::KexInit(server_kex_init)) => {
+                            println!("Successfully parsed server KEXINIT: {:?}", server_kex_init);
+
+                            // Check if read_next_message consumed the entire payload it was given
+                            if cursor.position() < msg_payload_length as u64 {
+                                eprintln!(
+                                    "Error: Did not consume entire KEXINIT message payload. Payload length: {}, Parsed: {}. Unparsed part: {:?}",
+                                    msg_payload_length,
+                                    cursor.position(),
+                                    (&ssh_message_payload_slice[cursor.position() as usize..]).hex_dump()
+                                );
+                                process::exit(1);
+                            }
+
+                            // Check if there are any extra unparsed bytes beyond the current SSH packet in the buffer
+                            if bytes_read > total_expected_bytes_for_this_packet {
+                                eprintln!(
+                                    "Error: Trailing bytes ({}) received after the current SSH packet. Total read: {}, Expected for packet: {}. Trailing data: {:?}",
+                                    bytes_read - total_expected_bytes_for_this_packet,
+                                    bytes_read,
+                                    total_expected_bytes_for_this_packet,
+                                    (&kex_buffer[total_expected_bytes_for_this_packet..bytes_read]).hex_dump()
+                                );
+                                process::exit(1);
+                            }
+
+                            // Algorithm Negotiation
+                            println!("\n--- Algorithm Negotiation ---");
+
+                            fn find_first_common(client_list: &[String], server_list: &[String]) -> Option<String> {
+                                client_list.iter().find(|algo| server_list.contains(algo)).cloned()
+                            }
+
+                            let chosen_kex_algo = find_first_common(
+                                &kex_init_payload.kex_algorithms,
+                                &server_kex_init.kex_algorithms,
+                            );
+                            match chosen_kex_algo {
+                                Some(algo) if algo == "ecdh-sha2-nistp256" => {
+                                    println!("Chosen KEX algorithm: {}", algo);
+                                    // Store for later: let chosen_kex_algo = algo;
+                                }
+                                Some(algo) => {
+                                    eprintln!("Unsupported KEX algorithm chosen: {}. We only support 'ecdh-sha2-nistp256'.", algo);
+                                    process::exit(1);
+                                }
+                                None => {
+                                    eprintln!("No common KEX algorithm found.");
+                                    eprintln!("Client offered: {:?}", kex_init_payload.kex_algorithms);
+                                    eprintln!("Server offered: {:?}", server_kex_init.kex_algorithms);
+                                    process::exit(1);
+                                }
+                            }
+
+                            let chosen_host_key_algo = find_first_common(
+                                &kex_init_payload.server_host_key_algorithms,
+                                &server_kex_init.server_host_key_algorithms,
+                            );
+                            match chosen_host_key_algo {
+                                Some(algo) => println!("Chosen server host key algorithm: {}", algo),
+                                None => {
+                                    eprintln!("No common server host key algorithm found.");
+                                    process::exit(1);
+                                }
+                            }
+
+                            let chosen_enc_c2s = find_first_common(
+                                &kex_init_payload.encryption_algorithms_client_to_server,
+                                &server_kex_init.encryption_algorithms_client_to_server,
+                            );
+                            match chosen_enc_c2s {
+                                Some(algo) if algo == "aes128-ctr" => {
+                                     println!("Chosen client-to-server encryption algorithm: {}", algo);
+                                }
+                                Some(algo) => {
+                                    eprintln!("Unsupported C2S encryption algorithm chosen: {}. We only support 'aes128-ctr'.", algo);
+                                    process::exit(1);
+                                }
+                                None => {
+                                    eprintln!("No common client-to-server encryption algorithm found.");
+                                    process::exit(1);
+                                }
+                            }
+
+                            let chosen_enc_s2c = find_first_common(
+                                &kex_init_payload.encryption_algorithms_server_to_client,
+                                &server_kex_init.encryption_algorithms_server_to_client,
+                            );
+                             match chosen_enc_s2c {
+                                Some(algo) if algo == "aes128-ctr" => {
+                                     println!("Chosen server-to-client encryption algorithm: {}", algo);
+                                }
+                                Some(algo) => {
+                                    eprintln!("Unsupported S2C encryption algorithm chosen: {}. We only support 'aes128-ctr'.", algo);
+                                    process::exit(1);
+                                }
+                                None => {
+                                    eprintln!("No common server-to-client encryption algorithm found.");
+                                    process::exit(1);
+                                }
+                            }
+
+                            let chosen_mac_c2s = find_first_common(
+                                &kex_init_payload.mac_algorithms_client_to_server,
+                                &server_kex_init.mac_algorithms_client_to_server,
+                            );
+                            match chosen_mac_c2s {
+                                Some(algo) if algo == "hmac-sha2-256" => {
+                                     println!("Chosen client-to-server MAC algorithm: {}", algo);
+                                }
+                                Some(algo) => {
+                                    eprintln!("Unsupported C2S MAC algorithm chosen: {}. We only support 'hmac-sha2-256'.", algo);
+                                    process::exit(1);
+                                }
+                                None => {
+                                    eprintln!("No common client-to-server MAC algorithm found.");
+                                    process::exit(1);
+                                }
+                            }
+
+                            let chosen_mac_s2c = find_first_common(
+                                &kex_init_payload.mac_algorithms_server_to_client,
+                                &server_kex_init.mac_algorithms_server_to_client,
+                            );
+                            match chosen_mac_s2c {
+                                Some(algo) if algo == "hmac-sha2-256" => {
+                                     println!("Chosen server-to-client MAC algorithm: {}", algo);
+                                }
+                                 Some(algo) => {
+                                    eprintln!("Unsupported S2C MAC algorithm chosen: {}. We only support 'hmac-sha2-256'.", algo);
+                                    process::exit(1);
+                                }
+                                None => {
+                                    eprintln!("No common server-to-client MAC algorithm found.");
+                                    process::exit(1);
+                                }
+                            }
+
+                            // Compression (assuming "none" is the only one we offer/accept for now)
+                            if kex_init_payload.compression_algorithms_client_to_server.get(0).map(String::as_str) == Some("none") &&
+                               server_kex_init.compression_algorithms_client_to_server.get(0).map(String::as_str) == Some("none") {
+                                println!("Chosen client-to-server compression: none");
+                            } else {
+                                eprintln!("Failed to agree on 'none' for C2S compression.");
+                                process::exit(1);
+                            }
+                             if kex_init_payload.compression_algorithms_server_to_client.get(0).map(String::as_str) == Some("none") &&
+                               server_kex_init.compression_algorithms_server_to_client.get(0).map(String::as_str) == Some("none") {
+                                println!("Chosen server-to-client compression: none");
+                            } else {
+                                eprintln!("Failed to agree on 'none' for S2C compression.");
+                                process::exit(1);
+                            }
+                            println!("--- Algorithm Negotiation Complete ---");
+
+                            // Part 2: ECDH Key Generation (if ecdh-sha2-nistp256 is chosen)
+                            // We've already confirmed chosen_kex_algo is Some("ecdh-sha2-nistp256")
+                            // so we can proceed.
+
+                            use openssl::bn::BigNumContext;
+                            use openssl::ec::{EcGroup, EcKey, PointConversionForm};
+                            use openssl::nid::Nid;
+                            use rand::Rng; // For random padding
+
+                            println!("\n--- ECDH Key Exchange (ecdh-sha2-nistp256) ---");
+
+                            let group = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1)
+                                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, format!("Failed to create EC group: {}", e)))?;
+                            let ec_key = EcKey::generate(&group)
+                                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, format!("Failed to generate EC key: {}", e)))?;
+
+                            let mut bn_ctx = BigNumContext::new()
+                                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, format!("Failed to create BigNumContext: {}", e)))?;
+
+                            let q_c_bytes = ec_key.public_key().to_bytes(
+                                &group,
+                                PointConversionForm::UNCOMPRESSED,
+                                &mut bn_ctx,
+                            ).map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, format!("Failed to get public key bytes: {}", e)))?;
+
+                            println!("Client ephemeral public key (Q_C) generated ({} bytes): {:?}", q_c_bytes.len(), q_c_bytes.hex_dump());
+
+                            // Part 3: Construct and Send MsgKexEcdhInit
+                            let kex_ecdh_init_msg = MsgKexECDHInit { q_c: q_c_bytes };
+
+                            let mut kex_ecdh_init_payload_bytes = Vec::new();
+                            // Manually write MAGIC first, then the struct for KexEcdhInit
+                            // because write_ssh on the struct itself doesn't add the MAGIC.
+                            // Correction: The derive ReadSSH/WriteSSH for enums like SSHMsg handles the magic.
+                            // When calling write_ssh on a specific message struct, we are writing the payload *after* magic.
+                            // The `read_next_message` reads magic then calls specific `Msg::read_ssh`.
+                            // So, for sending, we serialize the struct, then prepend magic for the payload.
+                            // No, this is also not quite right. write_ssh for the struct is for its fields.
+                            // The actual message construction should be:
+                            // 1. Create struct (e.g. kex_ecdh_init_msg)
+                            // 2. Create a Vec, write MAGIC to it.
+                            // 3. Call kex_ecdh_init_msg.write_ssh(&mut Vec) to append fields.
+                            // This Vec is then the "SSH Message Payload" for packetization.
+
+                            // kex_ecdh_init_payload_bytes.push(MsgKexECDHInit::MAGIC); // Removed: derived write_ssh should handle MAGIC
+                            kex_ecdh_init_msg.write_ssh(&mut kex_ecdh_init_payload_bytes)?;
+
+                            println!("Serialized MsgKexEcdhInit SSH message (incl. MAGIC, {} bytes): {:?}", kex_ecdh_init_payload_bytes.len(), kex_ecdh_init_payload_bytes.hex_dump());
+
+                            // Packet construction
+                            let block_size = 8; // Cipher block size (or 8 if no cipher yet)
+                            let payload_len = kex_ecdh_init_payload_bytes.len();
+
+                            // Calculate padding length: must be at least 4 bytes
+                            // total length of (padding_length_byte + payload + padding) must be multiple of block_size
+                            let mut padding_length = block_size - (1 + payload_len) % block_size;
+                            if padding_length < 4 {
+                                padding_length += block_size;
+                            }
+                            if padding_length >= 256 { // Should not happen with typical payloads and block_size
+                                eprintln!("Calculated excessive padding: {}", padding_length);
+                                process::exit(1);
+                            }
+
+
+                            let packet_len_field = (1 + payload_len + padding_length) as u32; // padding_length_byte + payload + random_padding
+
+                            let mut final_packet_bytes = Vec::new();
+                            final_packet_bytes.extend_from_slice(&packet_len_field.to_be_bytes());
+                            final_packet_bytes.push(padding_length as u8);
+                            final_packet_bytes.extend_from_slice(&kex_ecdh_init_payload_bytes);
+
+                            let mut padding_bytes = vec![0u8; padding_length];
+                            rand::thread_rng().fill(&mut padding_bytes[..]); // Removed ?
+                            final_packet_bytes.extend_from_slice(&padding_bytes);
+
+                            println!("Sending SSH_MSG_KEX_ECDH_INIT ({} bytes packet): {:?}", final_packet_bytes.len(), final_packet_bytes.hex_dump());
+                            println!("  Packet Length Field: {}", packet_len_field);
+                            println!("  Padding Length Field: {}", padding_length);
+                            println!("  Payload (MsgKexEcdhInit with MAGIC): {} bytes", payload_len);
+                            println!("  Padding: {} bytes", padding_length);
+
+
+                            if let Err(e) = stream.write_all(&final_packet_bytes) {
+                                eprintln!("Failed to send SSH_MSG_KEX_ECDH_INIT: {}", e);
+                                process::exit(1);
+                            }
+                            println!("SSH_MSG_KEX_ECDH_INIT sent.");
+
+                            // Next step would be to read MsgKexEcdhReply...
+                        }
+                        Ok(other_msg) => {
+                            eprintln!("Unexpected SSH message received instead of KEXINIT (parsed from payload): {:?}", other_msg);
+                            process::exit(1);
+                        }
+                        Err(e) => {
+                            eprintln!("Failed to parse server KEXINIT message: {}", e);
+                            process::exit(1);
+                        }
+                    }
+                }
+                Err(e) => {
+                    if e.kind() == std::io::ErrorKind::WouldBlock || e.kind() == std::io::ErrorKind::TimedOut {
+                        eprintln!("Timeout waiting for server KEXINIT message.");
+                    } else {
+                        eprintln!("Failed to read server KEXINIT message: {}", e);
+                    }
+                    process::exit(1);
+                }
+            }
+        }
+        Err(e) => {
+            eprintln!("Failed to connect to localhost:22: {}", e);
+            process::exit(1);
+        }
+    }
     Ok(())
 }

--- a/rustyssh/src/msg.rs
+++ b/rustyssh/src/msg.rs
@@ -364,7 +364,7 @@ impl SSHMagic for MsgNewKeys {
 
 #[derive(Debug, PartialEq, ReadSSH, WriteSSH)]
 pub struct MsgKexECDHInit {
-    pub q_c: String, // string   Q_C, client's ephemeral public key octet string
+    pub q_c: Vec<u8>, // string   Q_C, client's ephemeral public key octet string
 }
 
 impl SSHMagic for MsgKexECDHInit {


### PR DESCRIPTION
Changes include:
- Established TCP connection to the SSH server.
- Implemented sending and receiving of protocol version strings.
- Created and sent client KEXINIT message (MsgKexInit) with:
    - Random cookie generation.
    - Standard algorithm proposals (ecdh-sha2-nistp256, aes128-ctr, hmac-sha2-256).
- Received and parsed server KEXINIT message, including SSH packet framing.
- Implemented algorithm negotiation logic based on client/server proposals.
- Generated client's ephemeral ECDH public key (Q_C).
- Defined and sent MsgKexEcdhInit containing Q_C, with correct SSH packet framing.
- Updated msg.rs and api.rs to support Vec<u8> for SSH 'string' types, allowing correct serialization/deserialization of binary data.
- Added extensive logging for messages and byte streams.

I successfully sent the client's ephemeral public key. The next step is to receive and parse the server's MsgKexEcdhReply.